### PR TITLE
feat: add optional REST API wrapper (Part 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ An AI agent that analyzes satellite imagery for any location on Earth using natu
 
 ```
 ├── geo_agent/           # Core AI agent (Python)
+├── api-cdk/             # REST API wrapper (CDK) — optional
 ├── react-ui/            # Web UI (React + Express)
 ├── frontend-cdk/        # UI infrastructure (CDK)
 ├── titiler-cdk/         # Tile server (CDK)
@@ -62,6 +63,7 @@ This guide walks through deploying all three components:
 1. **Geo Agent** — AgentCore agent with satellite analysis tools (~5 min)
 2. **TiTiler** — Satellite imagery tile server (~2 min)
 3. **React UI Frontend** — Web interface with authentication (~7 min)
+4. **REST API** *(optional)* — API Gateway wrapper for external integrations (~3 min)
 
 ### Initial Setup (run once)
 
@@ -278,6 +280,225 @@ cd frontend-cdk && ./scripts/diagnose.sh
 
 ---
 
+## Part 4: Deploy REST API (Optional)
+
+> **This is optional.** Deploy this if you want external systems (e.g., a data mesh or other services) to call the geospatial agent via a standard REST API instead of invoking AgentCore directly.
+
+The REST API wraps the AgentCore agent behind API Gateway + Lambda with an async job pattern. Consumers submit analysis requests and poll for results — no timeout constraints. Authentication uses API keys.
+
+**Endpoints:**
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/analyze` | Submit an analysis job (returns immediately with a job ID) |
+| `GET` | `/jobs/{jobId}` | Poll for job status and results |
+| `GET` | `/capabilities` | List available analysis types and service metadata |
+
+### API Contract
+
+#### POST /analyze
+
+Submits a satellite imagery analysis job. Returns immediately with a job ID.
+
+**Request:**
+
+```json
+{
+  "location": "Central Park, New York",
+  "analysisType": "NDVI",
+  "dateRange": {
+    "start": "2025-01-01",
+    "end": "2025-01-31"
+  }
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `location` | string | yes | Location name or coordinates (e.g. `"Central Park, New York"` or `"41.37, 21.97"`) |
+| `analysisType` | string | yes | One of `"NDVI"` (vegetation), `"NDWI"` (water), `"NBR"` (burn severity) |
+| `dateRange` | object | no | `{ "start": "ISO date", "end": "ISO date" }` — defaults to most recent imagery |
+
+**Response (202 Accepted):**
+
+```json
+{
+  "jobId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "status": "PENDING",
+  "message": "Analysis submitted. Poll GET /jobs/{jobId} for results."
+}
+```
+
+#### GET /jobs/{jobId}
+
+Poll for job status and results.
+
+**Response (PENDING/RUNNING):**
+
+```json
+{
+  "jobId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "status": "RUNNING"
+}
+```
+
+**Response (COMPLETED):**
+
+```json
+{
+  "jobId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "status": "COMPLETED",
+  "result": {
+    "location": "Central Park, New York",
+    "analysisType": "NDVI",
+    "date": "2025-01-15",
+    "textAnalysis": "Vegetation health is moderate across the park...",
+    "statistics": {
+      "classes": [
+        { "name": "Dense Vegetation", "area_m2": 120000, "percentage": 45.2 },
+        { "name": "Sparse Vegetation", "area_m2": 80000, "percentage": 30.1 }
+      ],
+      "meanIndex": 0.42,
+      "medianIndex": 0.38
+    },
+    "imageUrls": {
+      "trueColor": "https://s3.amazonaws.com/...",
+      "indexMap": "https://s3.amazonaws.com/...",
+      "boundary": "https://s3.amazonaws.com/..."
+    },
+    "metadata": {
+      "satellite": "Sentinel-2",
+      "resolution": "10m",
+      "cloudCoverage": 12.5,
+      "source": "Copernicus / ESA"
+    }
+  }
+}
+```
+
+**Response (FAILED):**
+
+```json
+{
+  "jobId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "status": "FAILED",
+  "error": "Unable to process location 'xyznonexistent'"
+}
+```
+
+| Status | Description |
+|--------|-------------|
+| `PENDING` | Job submitted, waiting to start |
+| `RUNNING` | Agent is processing the analysis |
+| `COMPLETED` | Results available in `result` field |
+| `FAILED` | Error occurred, details in `error` field |
+
+#### GET /capabilities
+
+Returns available analysis types and service metadata.
+
+**Response:**
+
+```json
+{
+  "analysisTypes": [
+    { "id": "NDVI", "name": "Vegetation Health", "description": "Normalized Difference Vegetation Index" },
+    { "id": "NDWI", "name": "Water Detection", "description": "Normalized Difference Water Index" },
+    { "id": "NBR", "name": "Burn Severity", "description": "Normalized Burn Ratio" }
+  ],
+  "satellite": "Sentinel-2",
+  "coverage": "global",
+  "temporalRange": "60 days rolling",
+  "resolution": "10m"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `analysisTypes` | array | Available analysis types with id, name, and description |
+| `satellite` | string | Satellite source (`"Sentinel-2"`) |
+| `coverage` | string | Geographic coverage (`"global"`) |
+| `temporalRange` | string | How far back imagery is available (`"60 days rolling"`) |
+| `resolution` | string | Spatial resolution (`"10m"`) |
+
+**What gets deployed:** API Gateway REST API with API key auth, a DynamoDB table for job tracking, two Lambda functions (API handler + async worker), and IAM roles scoped to your agent.
+
+### Step 1: Configure
+
+> **Prerequisite:** The shell variables below must be set before running the `sed` command. If you deployed Parts 1–3 in the same terminal session, they're already set. If not, re-export them first:
+>
+> ```bash
+> export AGENT_RUNTIME_ARN=$(cd ../geo_agent && grep agent_arn .bedrock_agentcore.yaml | awk '{print $2}')
+> export S3_BUCKET_NAME=$(grep '^S3_BUCKET_NAME=' ../geo_agent/.env | cut -d= -f2)
+> ```
+
+```bash
+cd api-cdk
+cp .env.example .env
+
+# Auto-populate from shell variables
+sed -i.bak \
+  -e "s|AGENT_RUNTIME_ARN=.*|AGENT_RUNTIME_ARN=${AGENT_RUNTIME_ARN}|" \
+  -e "s|S3_BUCKET_NAME=.*|S3_BUCKET_NAME=${S3_BUCKET_NAME}|" \
+  .env && rm -f .env.bak
+
+# Verify values were populated
+cat .env
+```
+
+### Step 2: Deploy
+
+```bash
+./deploy.sh
+```
+
+The script installs dependencies, bootstraps CDK if needed, and deploys the stack. On success it prints the API URL and API Key ID.
+
+### Step 3: Retrieve API Key
+
+```bash
+API_URL=$(aws cloudformation describe-stacks \
+  --stack-name GeospatialAgentApiStack --region ${AWS_REGION} \
+  --query 'Stacks[0].Outputs[?OutputKey==`ApiUrl`].OutputValue' --output text)
+
+API_KEY_ID=$(aws cloudformation describe-stacks \
+  --stack-name GeospatialAgentApiStack --region ${AWS_REGION} \
+  --query 'Stacks[0].Outputs[?OutputKey==`ApiKeyId`].OutputValue' --output text)
+
+API_KEY=$(aws apigateway get-api-key \
+  --api-key ${API_KEY_ID} --include-value \
+  --query 'value' --output text --region ${AWS_REGION})
+
+echo "API URL: $API_URL"
+echo "API Key: $API_KEY"
+```
+
+### Step 4: Test
+
+```bash
+# Check capabilities
+curl -s -H "x-api-key: ${API_KEY}" ${API_URL}capabilities | jq .
+
+# Submit an analysis job (returns immediately with a job ID)
+JOB=$(curl -s -X POST -H "x-api-key: ${API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"location": "Central Park, New York", "analysisType": "NDVI"}' \
+  ${API_URL}analyze)
+echo $JOB | jq .
+JOB_ID=$(echo $JOB | jq -r '.jobId')
+
+# Poll for results (repeat until status is COMPLETED or FAILED)
+curl -s -H "x-api-key: ${API_KEY}" ${API_URL}jobs/${JOB_ID} | jq .
+```
+
+> **Polling:** The analysis typically takes 1–3 minutes. Poll `GET /jobs/{jobId}` every 10–15 seconds. Status transitions: `PENDING` → `RUNNING` → `COMPLETED` (or `FAILED`). Results include text analysis, area statistics, and presigned image URLs (valid for 1 hour).
+
+```bash
+cd ..
+```
+
+---
+
 ## Local Development (React UI)
 
 For local development without deploying to AWS:
@@ -348,6 +569,7 @@ The agent has access to these tools for geospatial analysis:
 - **React UI**: See `react-ui/README.md` for frontend architecture details
 - **Frontend CDK**: See `frontend-cdk/README.md` for deployment and authentication
 - **TiTiler**: See `titiler-cdk/README.md` for tile server deployment
+- **REST API**: See `api-cdk/` for the optional API Gateway wrapper (Part 4)
 - **Use Cases**: See `use-cases/README.md` for creating custom scenarios
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ An AI agent that analyzes satellite imagery for any location on Earth using natu
 
 ```
 ├── geo_agent/           # Core AI agent (Python)
-├── api-cdk/             # REST API wrapper (CDK) — optional
+├── api-cdk/             # REST API + MCP endpoint wrapper (CDK) — optional
 ├── react-ui/            # Web UI (React + Express)
 ├── frontend-cdk/        # UI infrastructure (CDK)
 ├── titiler-cdk/         # Tile server (CDK)
@@ -286,6 +286,8 @@ cd frontend-cdk && ./scripts/diagnose.sh
 
 The REST API wraps the AgentCore agent behind API Gateway + Lambda with an async job pattern. Consumers submit analysis requests and poll for results — no timeout constraints. Authentication uses API keys.
 
+This deployment also includes an **MCP (Model Context Protocol) endpoint** at `/mcp`, enabling AI agents and data mesh platforms to discover and invoke individual geospatial tools programmatically. See [MCP Endpoint](#mcp-endpoint) below.
+
 **Endpoints:**
 
 | Method | Path | Description |
@@ -293,6 +295,7 @@ The REST API wraps the AgentCore agent behind API Gateway + Lambda with an async
 | `POST` | `/analyze` | Submit an analysis job (returns immediately with a job ID) |
 | `GET` | `/jobs/{jobId}` | Poll for job status and results |
 | `GET` | `/capabilities` | List available analysis types and service metadata |
+| `POST` | `/mcp` | MCP JSON-RPC endpoint (initialize, tools/list, tools/call) |
 
 ### API Contract
 
@@ -493,6 +496,92 @@ curl -s -H "x-api-key: ${API_KEY}" ${API_URL}jobs/${JOB_ID} | jq .
 
 > **Polling:** The analysis typically takes 1–3 minutes. Poll `GET /jobs/{jobId}` every 10–15 seconds. Status transitions: `PENDING` → `RUNNING` → `COMPLETED` (or `FAILED`). Results include text analysis, area statistics, and presigned image URLs (valid for 1 hour).
 
+### MCP Endpoint
+
+The same deployment exposes an MCP (Model Context Protocol) endpoint at `POST /mcp`. This allows AI agents and data mesh platforms to discover and invoke individual geospatial tools via the standard MCP JSON-RPC protocol.
+
+**Authentication:** Uses a separate API Gateway API key (`geospatial-agent-mcp-api-key`), included in the same usage plan. The key value is automatically stored in SSM at `/geospatial-agent/mcp-api-key` during deployment.
+
+**Available tools:**
+
+| Tool | Description |
+|------|-------------|
+| `search_places` | Geocode location names — returns coordinates, addresses, and place metadata |
+| `find_location_boundary` | Get precise boundary polygons from OpenStreetMap |
+| `get_rasters` | Fetch Sentinel-2 satellite imagery bands (TCI, NIR, RED, SWIR2) |
+| `run_bandmath` | Calculate spectral indices (NDVI, NDWI, NBR) with statistics |
+| `display_visual` | Display geometry or imagery on a map |
+
+#### Retrieve MCP credentials
+
+```bash
+# MCP endpoint URL
+MCP_URL=$(aws cloudformation describe-stacks \
+  --stack-name GeospatialAgentApiStack --region ${AWS_REGION} \
+  --query 'Stacks[0].Outputs[?OutputKey==`McpEndpointUrl`].OutputValue' --output text)
+
+# MCP API key (from SSM — written there automatically by CDK)
+MCP_API_KEY=$(aws ssm get-parameter \
+  --name /geospatial-agent/mcp-api-key \
+  --with-decryption --query 'Parameter.Value' --output text \
+  --region ${AWS_REGION})
+
+echo "MCP URL: $MCP_URL"
+```
+
+#### Test MCP endpoint
+
+```bash
+# Initialize (MCP handshake)
+curl -s -X POST -H "x-api-key: ${MCP_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}},"id":"1"}' \
+  ${MCP_URL} | jq .
+
+# List available tools
+curl -s -X POST -H "x-api-key: ${MCP_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"tools/list","id":"2"}' \
+  ${MCP_URL} | jq .
+
+# Call a tool (search for a location)
+curl -s -X POST -H "x-api-key: ${MCP_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"search_places","arguments":{"query":"Central Park, New York"}},"id":"3"}' \
+  ${MCP_URL} | jq .
+```
+
+#### Register with a data mesh
+
+To register this MCP endpoint as a supplier in the ADSE Data Mesh:
+
+```bash
+# Read the MCP API key from SSM
+MCP_API_KEY=$(aws ssm get-parameter \
+  --name /geospatial-agent/mcp-api-key \
+  --with-decryption --query 'Parameter.Value' --output text \
+  --region ${AWS_REGION})
+
+# Register as an MCP supplier product
+curl -s -X POST -H "x-api-key: ${SUPPLIER_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "sentinel_2_geospatial_tools",
+    "description": "Sentinel-2 satellite imagery analysis tools — search places, get imagery, calculate spectral indices (NDVI/NDWI/NBR), and visualize results",
+    "classificationLevel": "UNCLASSIFIED",
+    "releasability": "UNRESTRICTED",
+    "mettcCategory": ["terrain"],
+    "militaryDomain": "geospatial",
+    "dataType": "mcp",
+    "mcpEndpointUrl": "'${MCP_URL}'",
+    "mcpAuthType": "api_key",
+    "mcpApiKey": "'${MCP_API_KEY}'"
+  }' \
+  ${MESH_API_URL}/suppliers/products | jq .
+```
+
+The mesh will store the API key in its own SSM, discover the available tools via `tools/list`, and make them available to subscribed consumers through the mesh's MCP proxy with full governance (DCS, audit, subscription checks).
+
 ```bash
 cd ..
 ```
@@ -570,6 +659,7 @@ The agent has access to these tools for geospatial analysis:
 - **Frontend CDK**: See `frontend-cdk/README.md` for deployment and authentication
 - **TiTiler**: See `titiler-cdk/README.md` for tile server deployment
 - **REST API**: See `api-cdk/` for the optional API Gateway wrapper (Part 4)
+- **MCP Endpoint**: Included in Part 4 — see [MCP Endpoint](#mcp-endpoint) for tool discovery and invocation via MCP protocol
 - **Use Cases**: See `use-cases/README.md` for creating custom scenarios
 
 ## Authors

--- a/api-cdk/.env.example
+++ b/api-cdk/.env.example
@@ -1,6 +1,3 @@
-# AWS Configuration
-AWS_REGION=eu-central-1
-
 # Bedrock AgentCore Runtime ARN (Required)
 # Get this from your deployed Python AgentCore agent
 AGENT_RUNTIME_ARN=arn:aws:bedrock-agentcore:eu-central-1:YOUR_ACCOUNT_ID:runtime/YOUR_AGENT_ID
@@ -8,11 +5,3 @@ AGENT_RUNTIME_ARN=arn:aws:bedrock-agentcore:eu-central-1:YOUR_ACCOUNT_ID:runtime
 # S3 Bucket Name (Required)
 # Same bucket created in Part 1
 S3_BUCKET_NAME=geospatial-agent-on-aws-YOUR_ACCOUNT_ID
-
-# Admin Email (Required)
-# Email for the initial admin user - will receive temporary password
-ADMIN_EMAIL=your-email@example.com
-
-# Optional: Stack customization
-# STACK_NAME=GeospatialAgentStack
-# ENVIRONMENT=dev

--- a/api-cdk/bin/app.ts
+++ b/api-cdk/bin/app.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+import 'source-map-support/register';
+import * as cdk from 'aws-cdk-lib';
+import { ApiStack } from '../lib/api-stack';
+
+const app = new cdk.App();
+
+const env = {
+  account: process.env.CDK_DEFAULT_ACCOUNT,
+  region: process.env.CDK_DEFAULT_REGION || 'us-east-1',
+};
+
+new ApiStack(app, 'GeospatialAgentApiStack', {
+  env,
+  description: 'Geospatial Agent REST API wrapper (Part 4)',
+});
+
+app.synth();

--- a/api-cdk/cdk.json
+++ b/api-cdk/cdk.json
@@ -1,0 +1,24 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/app.ts",
+  "watch": {
+    "include": ["**"],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/core:target-partitions": ["aws", "aws-cn"],
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true
+  }
+}

--- a/api-cdk/deploy.sh
+++ b/api-cdk/deploy.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ──────────────────────────────────────────────────────────────
+# deploy.sh — One-command deployment for the Geospatial Agent API
+# ──────────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+STACK_NAME="GeospatialAgentApiStack"
+
+# ── Colors ────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+info()  { echo -e "${CYAN}[INFO]${NC}  $*"; }
+ok()    { echo -e "${GREEN}[OK]${NC}    $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+err()   { echo -e "${RED}[ERROR]${NC} $*"; }
+
+# ── Prerequisite checks ──────────────────────────────────────
+info "Checking prerequisites..."
+
+if ! command -v node &>/dev/null; then
+  err "Node.js is not installed. Please install Node.js 18+ and try again."
+  exit 1
+fi
+ok "Node.js $(node --version)"
+
+if ! command -v aws &>/dev/null; then
+  err "AWS CLI is not installed. Please install the AWS CLI and try again."
+  exit 1
+fi
+ok "AWS CLI $(aws --version 2>&1 | head -1)"
+
+if ! command -v npx &>/dev/null; then
+  err "npx is not available. Please install Node.js 18+ (includes npm/npx)."
+  exit 1
+fi
+ok "npx available"
+
+# ── .env file ─────────────────────────────────────────────────
+if [ ! -f .env ]; then
+  if [ -f .env.example ]; then
+    warn ".env file not found — copying from .env.example"
+    cp .env.example .env
+    err "Please edit .env and fill in the required values, then re-run this script."
+    exit 1
+  else
+    err ".env file not found and no .env.example to copy from."
+    exit 1
+  fi
+fi
+
+info "Loading .env file..."
+# shellcheck disable=SC2046
+export $(grep -v '^\s*#' .env | grep -v '^\s*$' | xargs)
+
+# ── Validate required env vars ────────────────────────────────
+MISSING=0
+
+if [ -z "${AGENT_RUNTIME_ARN:-}" ] || [[ "$AGENT_RUNTIME_ARN" == *"YOUR_"* ]]; then
+  err "AGENT_RUNTIME_ARN is not set or still contains placeholder values. Update .env."
+  MISSING=1
+fi
+
+if [ -z "${S3_BUCKET_NAME:-}" ] || [[ "$S3_BUCKET_NAME" == *"YOUR_"* ]]; then
+  err "S3_BUCKET_NAME is not set or still contains placeholder values. Update .env."
+  MISSING=1
+fi
+
+if [ "$MISSING" -eq 1 ]; then
+  exit 1
+fi
+
+ok "AGENT_RUNTIME_ARN = ${AGENT_RUNTIME_ARN}"
+ok "S3_BUCKET_NAME    = ${S3_BUCKET_NAME}"
+ok "AWS_REGION        = ${AWS_REGION:-eu-central-1}"
+
+# ── Install dependencies ──────────────────────────────────────
+if [ ! -d node_modules ]; then
+  info "Installing npm dependencies..."
+  npm install
+else
+  ok "node_modules already present"
+fi
+
+# ── CDK Bootstrap (first-time setup) ─────────────────────────
+info "Ensuring CDK is bootstrapped..."
+npx cdk bootstrap 2>/dev/null || {
+  warn "CDK bootstrap may have already been run or encountered a non-fatal issue — continuing."
+}
+
+# ── Deploy ────────────────────────────────────────────────────
+info "Deploying ${STACK_NAME}..."
+npx cdk deploy --require-approval never
+
+# ── Print outputs ─────────────────────────────────────────────
+echo ""
+echo -e "${GREEN}════════════════════════════════════════════════════════════${NC}"
+echo -e "${GREEN}  Deployment complete!${NC}"
+echo -e "${GREEN}════════════════════════════════════════════════════════════${NC}"
+echo ""
+
+API_URL=$(aws cloudformation describe-stacks \
+  --stack-name "$STACK_NAME" \
+  --query "Stacks[0].Outputs[?OutputKey=='ApiUrl'].OutputValue" \
+  --output text 2>/dev/null || echo "")
+
+API_KEY_ID=$(aws cloudformation describe-stacks \
+  --stack-name "$STACK_NAME" \
+  --query "Stacks[0].Outputs[?OutputKey=='ApiKeyId'].OutputValue" \
+  --output text 2>/dev/null || echo "")
+
+if [ -n "$API_URL" ]; then
+  echo -e "  ${CYAN}API URL:${NC}    $API_URL"
+fi
+if [ -n "$API_KEY_ID" ]; then
+  echo -e "  ${CYAN}API Key ID:${NC} $API_KEY_ID"
+fi
+
+echo ""
+echo -e "${YELLOW}To retrieve your API key value, run:${NC}"
+if [ -n "$API_KEY_ID" ]; then
+  echo -e "  aws apigateway get-api-key --api-key ${API_KEY_ID} --include-value --query 'value' --output text"
+else
+  echo -e "  aws apigateway get-api-key --api-key <API_KEY_ID> --include-value --query 'value' --output text"
+fi
+
+echo ""
+echo -e "${YELLOW}Test the API:${NC}"
+if [ -n "$API_URL" ]; then
+  echo -e "  curl -s -H 'x-api-key: <YOUR_API_KEY>' ${API_URL}capabilities | jq ."
+else
+  echo -e "  curl -s -H 'x-api-key: <YOUR_API_KEY>' <API_URL>/capabilities | jq ."
+fi
+echo ""

--- a/api-cdk/deploy.sh
+++ b/api-cdk/deploy.sh
@@ -116,12 +116,29 @@ API_KEY_ID=$(aws cloudformation describe-stacks \
   --query "Stacks[0].Outputs[?OutputKey=='ApiKeyId'].OutputValue" \
   --output text 2>/dev/null || echo "")
 
+MCP_URL=$(aws cloudformation describe-stacks \
+  --stack-name "$STACK_NAME" \
+  --query "Stacks[0].Outputs[?OutputKey=='McpEndpointUrl'].OutputValue" \
+  --output text 2>/dev/null || echo "")
+
+MCP_KEY_ID=$(aws cloudformation describe-stacks \
+  --stack-name "$STACK_NAME" \
+  --query "Stacks[0].Outputs[?OutputKey=='McpApiKeyId'].OutputValue" \
+  --output text 2>/dev/null || echo "")
+
 if [ -n "$API_URL" ]; then
-  echo -e "  ${CYAN}API URL:${NC}    $API_URL"
+  echo -e "  ${CYAN}API URL:${NC}        $API_URL"
 fi
 if [ -n "$API_KEY_ID" ]; then
-  echo -e "  ${CYAN}API Key ID:${NC} $API_KEY_ID"
+  echo -e "  ${CYAN}API Key ID:${NC}     $API_KEY_ID"
 fi
+if [ -n "$MCP_URL" ]; then
+  echo -e "  ${CYAN}MCP URL:${NC}        $MCP_URL"
+fi
+if [ -n "$MCP_KEY_ID" ]; then
+  echo -e "  ${CYAN}MCP Key ID:${NC}     $MCP_KEY_ID"
+fi
+echo -e "  ${CYAN}MCP Key (SSM):${NC}  /geospatial-agent/mcp-api-key"
 
 echo ""
 echo -e "${YELLOW}To retrieve your API key value, run:${NC}"
@@ -132,10 +149,22 @@ else
 fi
 
 echo ""
-echo -e "${YELLOW}Test the API:${NC}"
+echo -e "${YELLOW}To retrieve your MCP API key value, run:${NC}"
+echo -e "  aws ssm get-parameter --name /geospatial-agent/mcp-api-key --with-decryption --query 'Parameter.Value' --output text"
+
+echo ""
+echo -e "${YELLOW}Test the REST API:${NC}"
 if [ -n "$API_URL" ]; then
   echo -e "  curl -s -H 'x-api-key: <YOUR_API_KEY>' ${API_URL}capabilities | jq ."
 else
   echo -e "  curl -s -H 'x-api-key: <YOUR_API_KEY>' <API_URL>/capabilities | jq ."
+fi
+
+echo ""
+echo -e "${YELLOW}Test the MCP endpoint:${NC}"
+if [ -n "$MCP_URL" ]; then
+  echo -e "  curl -s -X POST -H 'x-api-key: <MCP_API_KEY>' -H 'Content-Type: application/json' \\"
+  echo -e "    -d '{\"jsonrpc\":\"2.0\",\"method\":\"tools/list\",\"id\":\"1\"}' \\"
+  echo -e "    ${MCP_URL} | jq ."
 fi
 echo ""

--- a/api-cdk/lambda/api.py
+++ b/api-cdk/lambda/api.py
@@ -1,4 +1,4 @@
-"""API Lambda — handles submit, poll, and capabilities (sync, fast)."""
+"""API Lambda — handles submit, poll, capabilities, and MCP JSON-RPC."""
 
 import json
 import os
@@ -54,8 +54,15 @@ def _handle_submit(event):
         return _response(400, {"message": "Invalid JSON in request body"})
 
     location = body.get("location")
-    if not location or not isinstance(location, str) or not location.strip():
-        return _response(400, {"message": "Missing or invalid 'location' field"})
+    prompt = body.get("prompt")
+
+    # Either location or prompt is required. The agent's geocoding tools
+    # can extract place names from a natural language prompt.
+    has_location = location and isinstance(location, str) and location.strip()
+    has_prompt = prompt and isinstance(prompt, str) and prompt.strip()
+
+    if not has_location and not has_prompt:
+        return _response(400, {"message": "Missing 'location' or 'prompt' field"})
 
     analysis_type = body.get("analysisType")
     if not analysis_type:
@@ -130,4 +137,295 @@ def handler(event, context):
     if method == "GET" and "/jobs/" in resource:
         return _handle_poll(event)
 
+    if method == "POST" and resource == "/mcp":
+        return _handle_mcp(event)
+
     return _response(404, {"message": "Not Found"})
+
+
+# ---------------------------------------------------------------------------
+# MCP JSON-RPC handler
+# ---------------------------------------------------------------------------
+
+MCP_PROTOCOL_VERSION = "2025-03-26"
+MCP_SERVER_NAME = "geospatial-agent-mcp"
+MCP_SERVER_VERSION = "1.0.0"
+
+MCP_TOOLS = [
+    {
+        "name": "search_places",
+        "description": (
+            "Search for places using geocoding. Returns location coordinates, "
+            "addresses, and place metadata. Use for finding specific locations "
+            "by name or address."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Search query (address, place name, etc.)",
+                },
+                "max_results": {
+                    "type": "integer",
+                    "description": "Maximum number of results to return",
+                    "default": 5,
+                    "minimum": 1,
+                    "maximum": 50,
+                },
+            },
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "find_location_boundary",
+        "description": (
+            "Get the exact boundary polygon for a named location from "
+            "OpenStreetMap. Returns a GeoJSON polygon saved to S3. "
+            "Use for getting precise boundaries of parks, cities, regions."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": "Place name (e.g., 'Central Park', 'Paris')",
+                },
+            },
+            "required": ["location"],
+        },
+    },
+    {
+        "name": "get_rasters",
+        "description": (
+            "Get Sentinel-2 satellite imagery bands. Searches backwards 60 days "
+            "from the specified date. Returns S3 URLs for TCI, red, green, NIR, "
+            "NIR08, and SWIR2 bands."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": "Place name (for filenames)",
+                },
+                "geometry_s3_url": {
+                    "type": "string",
+                    "description": (
+                        "S3 URL of the boundary geometry from "
+                        "find_location_boundary or create_bbox_from_coordinates"
+                    ),
+                },
+                "current_date_str": {
+                    "type": "string",
+                    "description": (
+                        "End date of 60-day search window (YYYY-MM-DD). "
+                        "Searches from (date - 60 days) to date."
+                    ),
+                },
+                "max_cloud": {
+                    "type": "number",
+                    "description": "Maximum cloud coverage percentage",
+                    "default": 30,
+                },
+            },
+            "required": ["location"],
+        },
+    },
+    {
+        "name": "run_bandmath",
+        "description": (
+            "Calculate spectral indices (NDVI, NDWI, NBR) from satellite imagery. "
+            "NDVI measures vegetation health, NDWI detects water bodies, "
+            "NBR assesses burn severity. Returns statistics and classified area "
+            "percentages."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": "Place name",
+                },
+                "index_type": {
+                    "type": "string",
+                    "description": "Type of spectral index",
+                    "enum": ["NDVI", "NDWI", "NBR"],
+                },
+                "band1_url": {
+                    "type": "string",
+                    "description": (
+                        "S3 URL of first band (red for NDVI, green for NDWI, "
+                        "nir08 for NBR)"
+                    ),
+                },
+                "band2_url": {
+                    "type": "string",
+                    "description": (
+                        "S3 URL of second band (nir for NDVI/NDWI, "
+                        "swir2 for NBR)"
+                    ),
+                },
+                "date_str": {
+                    "type": "string",
+                    "description": "Date from get_rasters (YYYY-MM-DD)",
+                },
+                "geometry_s3_url": {
+                    "type": "string",
+                    "description": "S3 URL of geometry for clipping",
+                },
+            },
+            "required": ["location", "index_type", "band1_url", "band2_url"],
+        },
+    },
+    {
+        "name": "display_visual",
+        "description": (
+            "Display geometry or imagery (TCI, NDVI, NDWI, NBR) on a map. "
+            "Call immediately after each analysis result to visualize it."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "s3_url": {
+                    "type": "string",
+                    "description": "S3 URL to GeoJSON or raster",
+                },
+                "title": {
+                    "type": "string",
+                    "description": "Display title",
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Optional details",
+                    "default": "",
+                },
+            },
+            "required": ["s3_url", "title"],
+        },
+    },
+]
+
+
+def _jsonrpc_response(result, request_id):
+    """Build a JSON-RPC 2.0 success response."""
+    return _response(200, {"jsonrpc": "2.0", "result": result, "id": request_id})
+
+
+def _jsonrpc_error(code, message, request_id, status_code=200):
+    """Build a JSON-RPC 2.0 error response."""
+    return _response(status_code, {
+        "jsonrpc": "2.0",
+        "error": {"code": code, "message": message},
+        "id": request_id,
+    })
+
+
+def _handle_mcp(event):
+    """POST /mcp — MCP JSON-RPC handler.
+
+    Handles initialize, tools/list, and tools/call.
+    tools/call creates an async job and waits for the result (synchronous
+    from the caller's perspective, async internally via worker Lambda).
+
+    Authentication is handled by API Gateway (x-api-key header validated
+    against the MCP usage plan key).
+    """
+    raw_body = event.get("body")
+    if not raw_body:
+        return _jsonrpc_error(-32700, "Parse error: empty body", None, 400)
+
+    try:
+        body = json.loads(raw_body) if isinstance(raw_body, str) else raw_body
+    except (json.JSONDecodeError, TypeError):
+        return _jsonrpc_error(-32700, "Parse error: invalid JSON", None, 400)
+
+    method = body.get("method")
+    params = body.get("params", {})
+    request_id = body.get("id")
+
+    # --- initialize ---
+    if method == "initialize":
+        return _jsonrpc_response({
+            "protocolVersion": MCP_PROTOCOL_VERSION,
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": MCP_SERVER_NAME, "version": MCP_SERVER_VERSION},
+        }, request_id)
+
+    # --- notifications/initialized ---
+    if method == "notifications/initialized":
+        return _jsonrpc_response({}, request_id)
+
+    # --- tools/list ---
+    if method == "tools/list":
+        return _jsonrpc_response({"tools": MCP_TOOLS}, request_id)
+
+    # --- tools/call ---
+    if method == "tools/call":
+        tool_name = params.get("name")
+        tool_args = params.get("arguments", {})
+
+        if not tool_name:
+            return _jsonrpc_error(-32602, "Missing tool name", request_id)
+
+        valid_names = {t["name"] for t in MCP_TOOLS}
+        if tool_name not in valid_names:
+            return _jsonrpc_error(-32602, f"Unknown tool: {tool_name}", request_id)
+
+        # Create a job and invoke the worker synchronously.
+        # The worker handles the actual agent invocation.
+        job_id = str(uuid.uuid4())
+        now = int(time.time())
+        ttl = now + 86400
+
+        table = dynamodb.Table(JOBS_TABLE_NAME)
+        table.put_item(Item={
+            "jobId": job_id,
+            "status": "PENDING",
+            "request": {"mcp_tool_call": True, "tool_name": tool_name, "arguments": tool_args},
+            "createdAt": now,
+            "ttl": ttl,
+        })
+
+        # Invoke worker synchronously (RequestResponse) so we can return
+        # the result in this MCP response
+        try:
+            worker_response = lambda_client.invoke(
+                FunctionName=WORKER_FUNCTION_NAME,
+                InvocationType="RequestResponse",
+                Payload=json.dumps({
+                    "jobId": job_id,
+                    "request": {"mcp_tool_call": True, "tool_name": tool_name, "arguments": tool_args},
+                }),
+            )
+
+            # Read the worker result from DynamoDB
+            resp = table.get_item(Key={"jobId": job_id})
+            item = resp.get("Item", {})
+
+            if item.get("status") == "COMPLETED":
+                result_data = item.get("result", {})
+                return _jsonrpc_response({
+                    "content": [{"type": "text", "text": json.dumps(result_data) if isinstance(result_data, dict) else str(result_data)}],
+                }, request_id)
+            elif item.get("status") == "FAILED":
+                error_msg = item.get("error", "Tool execution failed")
+                return _jsonrpc_response({
+                    "content": [{"type": "text", "text": error_msg}],
+                    "isError": True,
+                }, request_id)
+            else:
+                # Still pending — shouldn't happen with sync invoke but handle gracefully
+                return _jsonrpc_response({
+                    "content": [{"type": "text", "text": f"Tool execution in progress. Poll job {job_id} for results."}],
+                    "isError": True,
+                }, request_id)
+
+        except Exception as e:
+            return _jsonrpc_response({
+                "content": [{"type": "text", "text": f"Tool execution failed: {str(e)}"}],
+                "isError": True,
+            }, request_id)
+
+    # --- Unknown method ---
+    return _jsonrpc_error(-32601, f"Method not found: {method}", request_id)

--- a/api-cdk/lambda/api.py
+++ b/api-cdk/lambda/api.py
@@ -1,0 +1,133 @@
+"""API Lambda — handles submit, poll, and capabilities (sync, fast)."""
+
+import json
+import os
+import time
+import uuid
+
+import boto3
+
+JOBS_TABLE_NAME = os.environ.get("JOBS_TABLE_NAME", "")
+WORKER_FUNCTION_NAME = os.environ.get("WORKER_FUNCTION_NAME", "")
+
+VALID_ANALYSIS_TYPES = ["NDVI", "NDWI", "NBR"]
+
+CAPABILITIES_RESPONSE = {
+    "analysisTypes": [
+        {"id": "NDVI", "name": "Vegetation Health", "description": "Normalized Difference Vegetation Index — measures live green vegetation"},
+        {"id": "NDWI", "name": "Water Detection", "description": "Normalized Difference Water Index — detects water bodies and moisture"},
+        {"id": "NBR", "name": "Burn Severity", "description": "Normalized Burn Ratio — assesses wildfire damage and burn severity"},
+    ],
+    "satellite": "Sentinel-2",
+    "coverage": "global",
+    "temporalRange": "60 days rolling",
+    "resolution": "10m",
+}
+
+CORS_HEADERS = {
+    "Content-Type": "application/json",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Headers": "Content-Type,X-Api-Key",
+}
+
+dynamodb = boto3.resource("dynamodb")
+lambda_client = boto3.client("lambda")
+
+
+def _response(status_code, body):
+    return {
+        "statusCode": status_code,
+        "headers": CORS_HEADERS,
+        "body": json.dumps(body),
+    }
+
+
+def _handle_submit(event):
+    """POST /analyze — validate, create job, invoke worker async."""
+    raw_body = event.get("body")
+    if not raw_body:
+        return _response(400, {"message": "Missing request body"})
+
+    try:
+        body = json.loads(raw_body) if isinstance(raw_body, str) else raw_body
+    except (json.JSONDecodeError, TypeError):
+        return _response(400, {"message": "Invalid JSON in request body"})
+
+    location = body.get("location")
+    if not location or not isinstance(location, str) or not location.strip():
+        return _response(400, {"message": "Missing or invalid 'location' field"})
+
+    analysis_type = body.get("analysisType")
+    if not analysis_type:
+        return _response(400, {"message": "Missing 'analysisType' field"})
+    if analysis_type not in VALID_ANALYSIS_TYPES:
+        return _response(400, {
+            "message": f"Invalid analysisType '{analysis_type}'. Must be one of: {', '.join(VALID_ANALYSIS_TYPES)}"
+        })
+
+    # Create job record
+    job_id = str(uuid.uuid4())
+    now = int(time.time())
+    ttl = now + 86400  # 24h expiry
+
+    table = dynamodb.Table(JOBS_TABLE_NAME)
+    table.put_item(Item={
+        "jobId": job_id,
+        "status": "PENDING",
+        "request": body,
+        "createdAt": now,
+        "ttl": ttl,
+    })
+
+    # Invoke worker async
+    lambda_client.invoke(
+        FunctionName=WORKER_FUNCTION_NAME,
+        InvocationType="Event",
+        Payload=json.dumps({"jobId": job_id, "request": body}),
+    )
+
+    return _response(202, {
+        "jobId": job_id,
+        "status": "PENDING",
+        "message": "Analysis submitted. Poll GET /jobs/{jobId} for results.",
+    })
+
+
+def _handle_poll(event):
+    """GET /jobs/{jobId} — return job status and results."""
+    job_id = event.get("pathParameters", {}).get("jobId")
+    if not job_id:
+        return _response(400, {"message": "Missing jobId"})
+
+    table = dynamodb.Table(JOBS_TABLE_NAME)
+    resp = table.get_item(Key={"jobId": job_id})
+    item = resp.get("Item")
+
+    if not item:
+        return _response(404, {"message": f"Job '{job_id}' not found"})
+
+    result = {"jobId": job_id, "status": item["status"]}
+
+    if item["status"] == "COMPLETED":
+        result["result"] = item.get("result", {})
+    elif item["status"] == "FAILED":
+        result["error"] = item.get("error", "Unknown error")
+
+    return _response(200, result)
+
+
+def handler(event, context):
+    """Route requests by method + path."""
+    method = event.get("httpMethod", "")
+    resource = event.get("resource") or event.get("path") or ""
+
+    if method == "GET" and resource == "/capabilities":
+        return _response(200, CAPABILITIES_RESPONSE)
+
+    if method == "POST" and resource == "/analyze":
+        return _handle_submit(event)
+
+    if method == "GET" and "/jobs/" in resource:
+        return _handle_poll(event)
+
+    return _response(404, {"message": "Not Found"})

--- a/api-cdk/lambda/handler.py
+++ b/api-cdk/lambda/handler.py
@@ -1,0 +1,335 @@
+"""Proxy Lambda for Geospatial Agent REST API."""
+
+import json
+import os
+import re
+from datetime import date
+from urllib.parse import urlparse, unquote
+
+import boto3
+from botocore.exceptions import ReadTimeoutError, ConnectTimeoutError, ClientError
+
+VALID_ANALYSIS_TYPES = ["NDVI", "NDWI", "NBR"]
+
+INVALID_LOCATION_INDICATORS = [
+    "could not find",
+    "invalid location",
+    "unable to locate",
+    "location not found",
+    "cannot find",
+    "unrecognized location",
+    "no results found",
+    "could not geocode",
+    "failed to geocode",
+    "unknown location",
+]
+
+CORS_HEADERS = {
+    "Content-Type": "application/json",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Headers": "Content-Type,X-Api-Key",
+    "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+}
+
+CAPABILITIES_RESPONSE = {
+    "analysisTypes": [
+        {
+            "id": "NDVI",
+            "name": "Normalized Difference Vegetation Index",
+            "description": "Measures vegetation health",
+        },
+        {
+            "id": "NDWI",
+            "name": "Normalized Difference Water Index",
+            "description": "Detects water bodies and moisture",
+        },
+        {
+            "id": "NBR",
+            "name": "Normalized Burn Ratio",
+            "description": "Assesses burn severity",
+        },
+    ],
+    "satellite": "Sentinel-2",
+    "coverage": "global",
+    "temporalRange": "60 days rolling",
+    "resolution": "10m",
+}
+
+
+def _response(status_code, body):
+    """Build an API Gateway Lambda proxy integration response."""
+    return {
+        "statusCode": status_code,
+        "headers": CORS_HEADERS,
+        "body": json.dumps(body),
+    }
+
+
+def _build_prompt(location, analysis_type, date_range=None):
+    """Construct a structured prompt for the AgentCore agent."""
+    prompt = f"Analyze {analysis_type} for {location}."
+    if date_range:
+        start = date_range.get("start", "")
+        end = date_range.get("end", "")
+        if start and end:
+            prompt += f" Use imagery from {start} to {end}."
+    prompt += " Return only the statistics and S3 URLs, no explanatory text."
+    return prompt
+
+
+def _invoke_agent(prompt):
+    """Invoke AgentCore runtime and collect the streamed text response."""
+    region = os.environ.get("AWS_REGION")
+    agent_runtime_arn = os.environ.get("AGENT_RUNTIME_ARN", "")
+
+    client = boto3.client("bedrock-agentcore", region_name=region)
+    payload = json.dumps({"prompt": prompt}).encode("utf-8")
+    response = client.invoke_agent_runtime(
+        agentRuntimeArn=agent_runtime_arn,
+        payload=payload,
+    )
+
+    # Process the streaming response
+    content_type = response.get("contentType", "")
+    chunks = []
+
+    if "text/event-stream" in content_type:
+        # SSE streaming response
+        for line in response["response"].iter_lines(chunk_size=10):
+            if line:
+                decoded = line.decode("utf-8") if isinstance(line, bytes) else line
+                if decoded.startswith("data: "):
+                    chunks.append(decoded[6:])
+                else:
+                    chunks.append(decoded)
+    elif response.get("response"):
+        # Standard response body
+        for chunk in response["response"]:
+            if isinstance(chunk, bytes):
+                chunks.append(chunk.decode("utf-8"))
+            else:
+                chunks.append(str(chunk))
+
+    return "".join(chunks)
+
+
+def _parse_agent_response(raw_text, location, analysis_type):
+    """Parse raw agent text into a structured AnalyzeResponse dict."""
+
+    # --- strip tool-use JSON objects from the text ---
+    tool_use_pattern = re.compile(
+        r'\{"toolUseId"\s*:.*?\}',
+        re.DOTALL,
+    )
+    clean_text = tool_use_pattern.sub("", raw_text).strip()
+
+    # --- extract statistics from embedded JSON blocks ---
+    statistics = None
+    # Look for a JSON block that contains a "classes" array
+    json_block_pattern = re.compile(r'\{[^{}]*"classes"\s*:\s*\[.*?\][^{}]*\}', re.DOTALL)
+    json_match = json_block_pattern.search(raw_text)
+    if json_match:
+        try:
+            stats_obj = json.loads(json_match.group())
+            classes = []
+            for c in stats_obj.get("classes", []):
+                classes.append({
+                    "name": str(c.get("name", "")),
+                    "area_m2": float(c.get("area_m2", 0)),
+                    "percentage": float(c.get("percentage", 0)),
+                })
+            statistics = {
+                "classes": classes,
+                "meanIndex": float(stats_obj.get("meanIndex", 0)),
+                "medianIndex": float(stats_obj.get("medianIndex", 0)),
+            }
+            # Remove the JSON block from the clean text
+            clean_text = json_block_pattern.sub("", clean_text).strip()
+        except (json.JSONDecodeError, ValueError, TypeError):
+            pass
+
+    # --- extract S3 URLs ---
+    s3_url_pattern = re.compile(r'((?:https?://[^\s]*?\.s3[^\s]*)|(?:s3://[^\s]+))')
+    s3_urls = s3_url_pattern.findall(raw_text)
+
+    image_urls = {"trueColor": None, "indexMap": None, "boundary": None}
+    for url in s3_urls:
+        lower = url.lower()
+        if "truecolor" in lower or "true_color" in lower or "true-color" in lower:
+            image_urls["trueColor"] = url
+        elif "boundary" in lower:
+            image_urls["boundary"] = url
+        elif "index" in lower or analysis_type.lower() in lower:
+            image_urls["indexMap"] = url
+        else:
+            # Assign to first empty slot
+            if image_urls["trueColor"] is None:
+                image_urls["trueColor"] = url
+            elif image_urls["indexMap"] is None:
+                image_urls["indexMap"] = url
+            elif image_urls["boundary"] is None:
+                image_urls["boundary"] = url
+
+    # --- extract cloud coverage ---
+    cloud_coverage = None
+    cloud_match = re.search(r'cloud\s*(?:coverage|cover)\s*[:\s]*(\d+(?:\.\d+)?)\s*%?', raw_text, re.IGNORECASE)
+    if cloud_match:
+        cloud_coverage = float(cloud_match.group(1))
+
+    # --- extract date ---
+    date_match = re.search(r'(\d{4}-\d{2}-\d{2})', raw_text)
+    analysis_date = date_match.group(1) if date_match else date.today().isoformat()
+
+    # --- clean up residual whitespace in textAnalysis ---
+    clean_text = re.sub(r'\n{3,}', '\n\n', clean_text).strip()
+
+    return {
+        "location": location,
+        "analysisType": analysis_type,
+        "date": analysis_date,
+        "textAnalysis": clean_text,
+        "statistics": statistics,
+        "imageUrls": image_urls,
+        "metadata": {
+            "satellite": "Sentinel-2",
+            "resolution": "10m",
+            "cloudCoverage": cloud_coverage,
+            "source": "Copernicus / ESA",
+        },
+    }
+
+
+def _generate_presigned_url(s3_url, expiration=3600):
+    """Convert an S3 URL to a presigned GET URL.
+
+    Supports both ``s3://bucket/key`` and
+    ``https://bucket.s3[.region].amazonaws.com/key`` formats.
+    Returns the original URL unchanged if parsing fails.
+    """
+    bucket = None
+    key = None
+
+    try:
+        if s3_url.startswith("s3://"):
+            # s3://bucket/key
+            parsed = urlparse(s3_url)
+            bucket = parsed.netloc
+            key = parsed.path.lstrip("/")
+        elif "s3" in s3_url and "amazonaws.com" in s3_url:
+            # https://bucket.s3[.region].amazonaws.com/key[?query]
+            parsed = urlparse(s3_url.split("?")[0])  # strip existing query params
+            host = parsed.hostname or ""
+            # bucket.s3.region.amazonaws.com  or  bucket.s3.amazonaws.com
+            parts = host.split(".s3")
+            if parts:
+                bucket = parts[0]
+            key = parsed.path.lstrip("/")
+            if key:
+                key = unquote(key)
+
+        if not bucket or not key:
+            # Fallback: use S3_BUCKET_NAME env var if bucket couldn't be parsed
+            fallback_bucket = os.environ.get("S3_BUCKET_NAME", "")
+            if fallback_bucket and key:
+                bucket = fallback_bucket
+            else:
+                return s3_url
+
+        region = os.environ.get("AWS_REGION", "us-east-1")
+        s3_client = boto3.client("s3", region_name=region)
+        return s3_client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": bucket, "Key": key},
+            ExpiresIn=expiration,
+        )
+    except Exception:
+        return s3_url
+
+
+def _is_invalid_location_response(raw_text):
+    """Check if the agent response indicates the location was invalid or not found."""
+    if not raw_text or not raw_text.strip():
+        return True
+    lower = raw_text.lower()
+    return any(indicator in lower for indicator in INVALID_LOCATION_INDICATORS)
+
+
+def _handle_analyze(event):
+    """Handle POST /analyze — validate, invoke AgentCore, return result."""
+    # Parse request body
+    raw_body = event.get("body")
+    if not raw_body:
+        return _response(400, {"message": "Missing request body"})
+
+    try:
+        body = json.loads(raw_body) if isinstance(raw_body, str) else raw_body
+    except (json.JSONDecodeError, TypeError):
+        return _response(400, {"message": "Invalid JSON in request body"})
+
+    # Validate required fields
+    location = body.get("location")
+    if not location or not isinstance(location, str) or not location.strip():
+        return _response(400, {"message": "Missing or invalid 'location' field"})
+
+    analysis_type = body.get("analysisType")
+    if not analysis_type:
+        return _response(400, {"message": "Missing 'analysisType' field"})
+    if analysis_type not in VALID_ANALYSIS_TYPES:
+        return _response(400, {
+            "message": f"Invalid analysisType '{analysis_type}'. Must be one of: {', '.join(VALID_ANALYSIS_TYPES)}"
+        })
+
+    date_range = body.get("dateRange")
+
+    # Build prompt and invoke agent
+    prompt = _build_prompt(location, analysis_type, date_range)
+
+    try:
+        raw_response = _invoke_agent(prompt)
+    except (ReadTimeoutError, ConnectTimeoutError):
+        return _response(504, {"message": "Agent request timed out. The geospatial analysis took too long to complete. Please try again."})
+    except ClientError as exc:
+        error_code = exc.response.get("Error", {}).get("Code", "")
+        if error_code in ("RequestTimeout", "RequestTimeoutException"):
+            return _response(504, {"message": "Agent request timed out. The geospatial analysis took too long to complete. Please try again."})
+        return _response(500, {"message": f"AgentCore invocation failed: {str(exc)}"})
+    except Exception as exc:
+        return _response(500, {"message": f"AgentCore invocation failed: {str(exc)}"})
+
+    # Detect invalid location from agent response
+    if _is_invalid_location_response(raw_response):
+        return _response(422, {
+            "message": f"Unable to process location '{location.strip()}'. The location could not be found or geocoded. Please provide a valid location name or coordinates."
+        })
+
+    result = _parse_agent_response(raw_response, location.strip(), analysis_type)
+
+    # Convert raw S3 URLs to presigned URLs
+    for url_key, url_value in result["imageUrls"].items():
+        if url_value is not None:
+            result["imageUrls"][url_key] = _generate_presigned_url(url_value)
+
+    return _response(200, result)
+
+
+def handler(event, context):
+    """Lambda entry point — routes requests by method + path.
+    Supports both API Gateway REST and Lambda Function URL event formats.
+    """
+    # API Gateway REST format
+    method = event.get("httpMethod", "")
+    resource = event.get("resource") or event.get("path") or ""
+
+    # Lambda Function URL format
+    if not method:
+        req_ctx = event.get("requestContext", {}).get("http", {})
+        method = req_ctx.get("method", "")
+        resource = req_ctx.get("path", "")
+
+    if method == "GET" and resource == "/capabilities":
+        return _response(200, CAPABILITIES_RESPONSE)
+
+    if method == "POST" and resource == "/analyze":
+        return _handle_analyze(event)
+
+    return _response(404, {"message": "Not Found"})

--- a/api-cdk/lambda/test_handler.py
+++ b/api-cdk/lambda/test_handler.py
@@ -1,0 +1,617 @@
+"""Tests for the proxy Lambda handler."""
+
+import json
+import unittest
+from datetime import date
+from unittest.mock import patch, MagicMock
+
+from handler import handler, CAPABILITIES_RESPONSE, VALID_ANALYSIS_TYPES, _parse_agent_response, _generate_presigned_url, _is_invalid_location_response
+
+
+class TestCapabilities(unittest.TestCase):
+    """GET /capabilities returns the static capabilities payload."""
+
+    def test_returns_200(self):
+        event = {"httpMethod": "GET", "resource": "/capabilities"}
+        resp = handler(event, None)
+        self.assertEqual(resp["statusCode"], 200)
+
+    def test_body_matches_static_payload(self):
+        event = {"httpMethod": "GET", "resource": "/capabilities"}
+        resp = handler(event, None)
+        body = json.loads(resp["body"])
+        self.assertEqual(body, CAPABILITIES_RESPONSE)
+
+    def test_analysis_types_count(self):
+        event = {"httpMethod": "GET", "resource": "/capabilities"}
+        body = json.loads(handler(event, None)["body"])
+        self.assertEqual(len(body["analysisTypes"]), 3)
+
+    def test_analysis_type_ids(self):
+        event = {"httpMethod": "GET", "resource": "/capabilities"}
+        body = json.loads(handler(event, None)["body"])
+        ids = [t["id"] for t in body["analysisTypes"]]
+        self.assertEqual(ids, ["NDVI", "NDWI", "NBR"])
+
+    def test_fixed_fields(self):
+        event = {"httpMethod": "GET", "resource": "/capabilities"}
+        body = json.loads(handler(event, None)["body"])
+        self.assertEqual(body["satellite"], "Sentinel-2")
+        self.assertEqual(body["coverage"], "global")
+        self.assertEqual(body["temporalRange"], "60 days rolling")
+        self.assertEqual(body["resolution"], "10m")
+
+    def test_cors_headers(self):
+        event = {"httpMethod": "GET", "resource": "/capabilities"}
+        resp = handler(event, None)
+        self.assertEqual(resp["headers"]["Content-Type"], "application/json")
+        self.assertIn("Access-Control-Allow-Origin", resp["headers"])
+
+    def test_path_fallback(self):
+        """When 'resource' is absent, handler falls back to 'path'."""
+        event = {"httpMethod": "GET", "path": "/capabilities"}
+        resp = handler(event, None)
+        self.assertEqual(resp["statusCode"], 200)
+
+
+class TestAnalyzeValidation(unittest.TestCase):
+    """POST /analyze request validation."""
+
+    def _post(self, body=None):
+        event = {"httpMethod": "POST", "resource": "/analyze"}
+        if body is not None:
+            event["body"] = json.dumps(body) if isinstance(body, dict) else body
+        return handler(event, None)
+
+    def test_missing_body_returns_400(self):
+        resp = self._post()
+        self.assertEqual(resp["statusCode"], 400)
+
+    def test_invalid_json_returns_400(self):
+        event = {"httpMethod": "POST", "resource": "/analyze", "body": "not json"}
+        resp = handler(event, None)
+        self.assertEqual(resp["statusCode"], 400)
+
+    def test_missing_location_returns_400(self):
+        resp = self._post({"analysisType": "NDVI"})
+        self.assertEqual(resp["statusCode"], 400)
+        body = json.loads(resp["body"])
+        self.assertIn("location", body["message"].lower())
+
+    def test_empty_location_returns_400(self):
+        resp = self._post({"location": "  ", "analysisType": "NDVI"})
+        self.assertEqual(resp["statusCode"], 400)
+
+    def test_missing_analysis_type_returns_400(self):
+        resp = self._post({"location": "Central Park"})
+        self.assertEqual(resp["statusCode"], 400)
+        body = json.loads(resp["body"])
+        self.assertIn("analysisType", body["message"])
+
+    def test_invalid_analysis_type_returns_400(self):
+        resp = self._post({"location": "Central Park", "analysisType": "INVALID"})
+        self.assertEqual(resp["statusCode"], 400)
+        body = json.loads(resp["body"])
+        self.assertIn("INVALID", body["message"])
+
+    def test_all_valid_types_accepted(self):
+        for t in VALID_ANALYSIS_TYPES:
+            self.assertIn(t, ["NDVI", "NDWI", "NBR"])
+
+
+class TestAnalyzeInvocation(unittest.TestCase):
+    """POST /analyze with mocked AgentCore invocation."""
+
+    @patch("handler.boto3")
+    @patch.dict("os.environ", {"AWS_REGION": "us-east-1", "AGENT_RUNTIME_ARN": "arn:aws:test"})
+    def test_successful_invocation(self, mock_boto3):
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.invoke_agent_runtime.return_value = {
+            "stream": [{"chunk": {"bytes": b"NDVI result text"}}]
+        }
+        mock_client.generate_presigned_url.return_value = "https://presigned-url"
+
+        event = {
+            "httpMethod": "POST",
+            "resource": "/analyze",
+            "body": json.dumps({"location": "Central Park", "analysisType": "NDVI"}),
+        }
+        resp = handler(event, None)
+        self.assertEqual(resp["statusCode"], 200)
+
+        body = json.loads(resp["body"])
+        self.assertEqual(body["location"], "Central Park")
+        self.assertEqual(body["analysisType"], "NDVI")
+        self.assertEqual(body["textAnalysis"], "NDVI result text")
+        self.assertIn("date", body)
+        self.assertIsNone(body["statistics"])
+        self.assertEqual(body["metadata"]["satellite"], "Sentinel-2")
+        self.assertEqual(body["metadata"]["source"], "Copernicus / ESA")
+
+    @patch("handler.boto3")
+    @patch.dict("os.environ", {"AWS_REGION": "us-east-1", "AGENT_RUNTIME_ARN": "arn:aws:test"})
+    def test_invocation_with_date_range(self, mock_boto3):
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.invoke_agent_runtime.return_value = {"stream": [{"text": "result"}]}
+
+        event = {
+            "httpMethod": "POST",
+            "resource": "/analyze",
+            "body": json.dumps({
+                "location": "Vardar River",
+                "analysisType": "NDWI",
+                "dateRange": {"start": "2024-01-01", "end": "2024-01-31"},
+            }),
+        }
+        resp = handler(event, None)
+        self.assertEqual(resp["statusCode"], 200)
+
+        # Verify the prompt includes the date range
+        call_args = mock_client.invoke_agent_runtime.call_args
+        prompt = call_args[1].get("prompt") or call_args[0][0] if call_args[0] else call_args[1]["prompt"]
+        self.assertIn("2024-01-01", prompt)
+        self.assertIn("2024-01-31", prompt)
+
+    @patch("handler.boto3")
+    @patch.dict("os.environ", {"AWS_REGION": "us-east-1", "AGENT_RUNTIME_ARN": "arn:aws:test"})
+    def test_agent_error_returns_500(self, mock_boto3):
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.invoke_agent_runtime.side_effect = Exception("Agent timeout")
+
+        event = {
+            "httpMethod": "POST",
+            "resource": "/analyze",
+            "body": json.dumps({"location": "Central Park", "analysisType": "NBR"}),
+        }
+        resp = handler(event, None)
+        self.assertEqual(resp["statusCode"], 500)
+        body = json.loads(resp["body"])
+        self.assertIn("AgentCore invocation failed", body["message"])
+
+
+class TestUnknownRoute(unittest.TestCase):
+    """Unknown routes return 404."""
+
+    def test_unknown_path(self):
+        event = {"httpMethod": "GET", "resource": "/unknown"}
+        resp = handler(event, None)
+        self.assertEqual(resp["statusCode"], 404)
+
+    def test_wrong_method(self):
+        event = {"httpMethod": "DELETE", "resource": "/capabilities"}
+        resp = handler(event, None)
+        self.assertEqual(resp["statusCode"], 404)
+
+
+class TestParseAgentResponse(unittest.TestCase):
+    """Tests for _parse_agent_response parsing logic."""
+
+    def test_embedded_json_statistics(self):
+        raw = (
+            'Vegetation analysis complete. '
+            '{"classes": [{"name": "Dense Vegetation", "area_m2": 5000.0, "percentage": 60.5}], '
+            '"meanIndex": 0.72, "medianIndex": 0.68} '
+            'The area shows healthy vegetation on 2024-06-15.'
+        )
+        result = _parse_agent_response(raw, "Central Park", "NDVI")
+        self.assertIsNotNone(result["statistics"])
+        self.assertEqual(len(result["statistics"]["classes"]), 1)
+        self.assertEqual(result["statistics"]["classes"][0]["name"], "Dense Vegetation")
+        self.assertAlmostEqual(result["statistics"]["classes"][0]["area_m2"], 5000.0)
+        self.assertAlmostEqual(result["statistics"]["classes"][0]["percentage"], 60.5)
+        self.assertAlmostEqual(result["statistics"]["meanIndex"], 0.72)
+        self.assertAlmostEqual(result["statistics"]["medianIndex"], 0.68)
+        self.assertEqual(result["date"], "2024-06-15")
+
+    def test_s3_urls_extracted(self):
+        raw = (
+            'Analysis complete. True color image: s3://my-bucket/truecolor/img.tif '
+            'Index map: s3://my-bucket/ndvi-index/map.tif '
+            'Boundary: s3://my-bucket/boundary/area.geojson'
+        )
+        result = _parse_agent_response(raw, "Vardar River", "NDVI")
+        self.assertEqual(result["imageUrls"]["trueColor"], "s3://my-bucket/truecolor/img.tif")
+        self.assertEqual(result["imageUrls"]["indexMap"], "s3://my-bucket/ndvi-index/map.tif")
+        self.assertEqual(result["imageUrls"]["boundary"], "s3://my-bucket/boundary/area.geojson")
+
+    def test_no_statistics_returns_none(self):
+        raw = "Simple text analysis with no JSON data."
+        result = _parse_agent_response(raw, "Test Location", "NDWI")
+        self.assertIsNone(result["statistics"])
+        self.assertEqual(result["textAnalysis"], "Simple text analysis with no JSON data.")
+        self.assertEqual(result["imageUrls"]["trueColor"], None)
+        self.assertEqual(result["imageUrls"]["indexMap"], None)
+        self.assertEqual(result["imageUrls"]["boundary"], None)
+
+    def test_tool_use_json_stripped(self):
+        raw = (
+            '{"toolUseId": "abc123", "name": "find_location_boundary", "input": "some data"}'
+            ' The vegetation health is good. '
+            '{"toolUseId": "def456", "name": "run_bandmath", "input": "more data"}'
+            ' NDVI values are above average.'
+        )
+        result = _parse_agent_response(raw, "Test Area", "NDVI")
+        self.assertNotIn("toolUseId", result["textAnalysis"])
+        self.assertIn("vegetation health is good", result["textAnalysis"])
+        self.assertIn("NDVI values are above average", result["textAnalysis"])
+
+    def test_metadata_always_present(self):
+        raw = "Any text."
+        result = _parse_agent_response(raw, "Loc", "NBR")
+        self.assertEqual(result["metadata"]["satellite"], "Sentinel-2")
+        self.assertEqual(result["metadata"]["resolution"], "10m")
+        self.assertEqual(result["metadata"]["source"], "Copernicus / ESA")
+        self.assertIsNone(result["metadata"]["cloudCoverage"])
+
+    def test_cloud_coverage_extracted(self):
+        raw = "Analysis done. Cloud coverage: 12.5% over the area."
+        result = _parse_agent_response(raw, "Loc", "NDVI")
+        self.assertAlmostEqual(result["metadata"]["cloudCoverage"], 12.5)
+
+    def test_date_defaults_to_today(self):
+        raw = "No date mentioned in this text."
+        result = _parse_agent_response(raw, "Loc", "NDVI")
+        self.assertEqual(result["date"], date.today().isoformat())
+
+    def test_presigned_s3_urls(self):
+        raw = (
+            'Here is the true color image: '
+            'https://my-bucket.s3.amazonaws.com/truecolor/img.tif?X-Amz-Signature=abc '
+            'and the index: '
+            'https://my-bucket.s3.us-east-1.amazonaws.com/ndvi-index/map.tif?sig=def'
+        )
+        result = _parse_agent_response(raw, "Loc", "NDVI")
+        self.assertIsNotNone(result["imageUrls"]["trueColor"])
+        self.assertIn("truecolor", result["imageUrls"]["trueColor"])
+
+
+class TestGeneratePresignedUrl(unittest.TestCase):
+    """Tests for _generate_presigned_url."""
+
+    @patch("handler.boto3")
+    @patch.dict("os.environ", {"AWS_REGION": "us-east-1"})
+    def test_s3_protocol_url(self, mock_boto3):
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.generate_presigned_url.return_value = "https://presigned-url"
+
+        result = _generate_presigned_url("s3://my-bucket/path/to/image.tif")
+        self.assertEqual(result, "https://presigned-url")
+        mock_client.generate_presigned_url.assert_called_once_with(
+            "get_object",
+            Params={"Bucket": "my-bucket", "Key": "path/to/image.tif"},
+            ExpiresIn=3600,
+        )
+
+    @patch("handler.boto3")
+    @patch.dict("os.environ", {"AWS_REGION": "us-west-2"})
+    def test_https_s3_url_with_region(self, mock_boto3):
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.generate_presigned_url.return_value = "https://presigned-url"
+
+        result = _generate_presigned_url(
+            "https://my-bucket.s3.us-west-2.amazonaws.com/ndvi/map.tif"
+        )
+        self.assertEqual(result, "https://presigned-url")
+        mock_client.generate_presigned_url.assert_called_once_with(
+            "get_object",
+            Params={"Bucket": "my-bucket", "Key": "ndvi/map.tif"},
+            ExpiresIn=3600,
+        )
+
+    @patch("handler.boto3")
+    @patch.dict("os.environ", {"AWS_REGION": "us-east-1"})
+    def test_https_s3_url_without_region(self, mock_boto3):
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.generate_presigned_url.return_value = "https://presigned-url"
+
+        result = _generate_presigned_url(
+            "https://my-bucket.s3.amazonaws.com/truecolor/img.tif"
+        )
+        self.assertEqual(result, "https://presigned-url")
+        mock_client.generate_presigned_url.assert_called_once_with(
+            "get_object",
+            Params={"Bucket": "my-bucket", "Key": "truecolor/img.tif"},
+            ExpiresIn=3600,
+        )
+
+    @patch("handler.boto3")
+    @patch.dict("os.environ", {"AWS_REGION": "us-east-1"})
+    def test_https_url_with_query_params_stripped(self, mock_boto3):
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.generate_presigned_url.return_value = "https://presigned-url"
+
+        result = _generate_presigned_url(
+            "https://my-bucket.s3.amazonaws.com/img.tif?X-Amz-Signature=abc"
+        )
+        self.assertEqual(result, "https://presigned-url")
+        mock_client.generate_presigned_url.assert_called_once_with(
+            "get_object",
+            Params={"Bucket": "my-bucket", "Key": "img.tif"},
+            ExpiresIn=3600,
+        )
+
+    def test_non_s3_url_returned_unchanged(self):
+        url = "https://example.com/image.tif"
+        result = _generate_presigned_url(url)
+        self.assertEqual(result, url)
+
+    def test_empty_string_returned_unchanged(self):
+        result = _generate_presigned_url("")
+        self.assertEqual(result, "")
+
+    @patch("handler.boto3")
+    @patch.dict("os.environ", {"AWS_REGION": "us-east-1"})
+    def test_custom_expiration(self, mock_boto3):
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.generate_presigned_url.return_value = "https://presigned-url"
+
+        _generate_presigned_url("s3://bucket/key.tif", expiration=7200)
+        mock_client.generate_presigned_url.assert_called_once_with(
+            "get_object",
+            Params={"Bucket": "bucket", "Key": "key.tif"},
+            ExpiresIn=7200,
+        )
+
+    @patch("handler.boto3")
+    @patch.dict("os.environ", {"AWS_REGION": "us-east-1", "S3_BUCKET_NAME": "fallback-bucket"})
+    def test_fallback_bucket_from_env(self, mock_boto3):
+        """When bucket can't be parsed but key is available, use S3_BUCKET_NAME."""
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.generate_presigned_url.return_value = "https://presigned-url"
+
+        # s3:// with empty netloc but a path — bucket is empty, key is present
+        result = _generate_presigned_url("s3:///just-a-key.tif")
+        # bucket is empty, key is "just-a-key.tif", fallback bucket used
+        self.assertEqual(result, "https://presigned-url")
+        mock_client.generate_presigned_url.assert_called_once_with(
+            "get_object",
+            Params={"Bucket": "fallback-bucket", "Key": "just-a-key.tif"},
+            ExpiresIn=3600,
+        )
+
+    @patch("handler.boto3")
+    @patch.dict("os.environ", {"AWS_REGION": "us-east-1"})
+    def test_boto3_error_returns_original(self, mock_boto3):
+        mock_boto3.client.side_effect = Exception("Connection error")
+        url = "s3://my-bucket/image.tif"
+        result = _generate_presigned_url(url)
+        self.assertEqual(result, url)
+
+
+class TestAnalyzePresignedIntegration(unittest.TestCase):
+    """Verify _handle_analyze converts S3 URLs to presigned URLs."""
+
+    @patch("handler.boto3")
+    @patch.dict("os.environ", {"AWS_REGION": "us-east-1", "AGENT_RUNTIME_ARN": "arn:aws:test"})
+    def test_image_urls_are_presigned(self, mock_boto3):
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.invoke_agent_runtime.return_value = {
+            "stream": [
+                {"chunk": {"bytes": b"True color: s3://bucket/truecolor/img.tif Index: s3://bucket/ndvi/map.tif"}}
+            ]
+        }
+        mock_client.generate_presigned_url.return_value = "https://presigned-url"
+
+        event = {
+            "httpMethod": "POST",
+            "resource": "/analyze",
+            "body": json.dumps({"location": "Central Park", "analysisType": "NDVI"}),
+        }
+        resp = handler(event, None)
+        body = json.loads(resp["body"])
+
+        self.assertEqual(body["imageUrls"]["trueColor"], "https://presigned-url")
+        self.assertEqual(body["imageUrls"]["indexMap"], "https://presigned-url")
+        # generate_presigned_url should have been called for each non-None URL
+        self.assertEqual(mock_client.generate_presigned_url.call_count, 2)
+
+    @patch("handler.boto3")
+    @patch.dict("os.environ", {"AWS_REGION": "us-east-1", "AGENT_RUNTIME_ARN": "arn:aws:test"})
+    def test_none_urls_not_presigned(self, mock_boto3):
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.invoke_agent_runtime.return_value = {
+            "stream": [{"chunk": {"bytes": b"No images here."}}]
+        }
+
+        event = {
+            "httpMethod": "POST",
+            "resource": "/analyze",
+            "body": json.dumps({"location": "Central Park", "analysisType": "NDVI"}),
+        }
+        resp = handler(event, None)
+        body = json.loads(resp["body"])
+
+        self.assertIsNone(body["imageUrls"]["trueColor"])
+        self.assertIsNone(body["imageUrls"]["indexMap"])
+        self.assertIsNone(body["imageUrls"]["boundary"])
+        mock_client.generate_presigned_url.assert_not_called()
+
+
+class TestAgentTimeoutHandling(unittest.TestCase):
+    """Agent timeout errors return 504 Gateway Timeout."""
+
+    def _post(self, body):
+        return {
+            "httpMethod": "POST",
+            "resource": "/analyze",
+            "body": json.dumps(body),
+        }
+
+    @patch("handler.boto3")
+    @patch.dict("os.environ", {"AWS_REGION": "us-east-1", "AGENT_RUNTIME_ARN": "arn:aws:test"})
+    def test_read_timeout_returns_504(self, mock_boto3):
+        from botocore.exceptions import ReadTimeoutError
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.invoke_agent_runtime.side_effect = ReadTimeoutError(endpoint_url="https://test")
+
+        resp = handler(self._post({"location": "Central Park", "analysisType": "NDVI"}), None)
+        self.assertEqual(resp["statusCode"], 504)
+        body = json.loads(resp["body"])
+        self.assertIn("timed out", body["message"])
+
+    @patch("handler.boto3")
+    @patch.dict("os.environ", {"AWS_REGION": "us-east-1", "AGENT_RUNTIME_ARN": "arn:aws:test"})
+    def test_connect_timeout_returns_504(self, mock_boto3):
+        from botocore.exceptions import ConnectTimeoutError
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.invoke_agent_runtime.side_effect = ConnectTimeoutError(endpoint_url="https://test")
+
+        resp = handler(self._post({"location": "Central Park", "analysisType": "NDVI"}), None)
+        self.assertEqual(resp["statusCode"], 504)
+        body = json.loads(resp["body"])
+        self.assertIn("timed out", body["message"])
+
+    @patch("handler.boto3")
+    @patch.dict("os.environ", {"AWS_REGION": "us-east-1", "AGENT_RUNTIME_ARN": "arn:aws:test"})
+    def test_client_error_request_timeout_returns_504(self, mock_boto3):
+        from botocore.exceptions import ClientError
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.invoke_agent_runtime.side_effect = ClientError(
+            {"Error": {"Code": "RequestTimeout", "Message": "Request timed out"}},
+            "InvokeAgentRuntime",
+        )
+
+        resp = handler(self._post({"location": "Central Park", "analysisType": "NDVI"}), None)
+        self.assertEqual(resp["statusCode"], 504)
+        body = json.loads(resp["body"])
+        self.assertIn("timed out", body["message"])
+
+    @patch("handler.boto3")
+    @patch.dict("os.environ", {"AWS_REGION": "us-east-1", "AGENT_RUNTIME_ARN": "arn:aws:test"})
+    def test_non_timeout_client_error_returns_500(self, mock_boto3):
+        from botocore.exceptions import ClientError
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.invoke_agent_runtime.side_effect = ClientError(
+            {"Error": {"Code": "AccessDeniedException", "Message": "Not authorized"}},
+            "InvokeAgentRuntime",
+        )
+
+        resp = handler(self._post({"location": "Central Park", "analysisType": "NDVI"}), None)
+        self.assertEqual(resp["statusCode"], 500)
+        body = json.loads(resp["body"])
+        self.assertIn("AgentCore invocation failed", body["message"])
+
+
+class TestInvalidLocationHandling(unittest.TestCase):
+    """Invalid location detection returns 422."""
+
+    def _post(self, body):
+        return {
+            "httpMethod": "POST",
+            "resource": "/analyze",
+            "body": json.dumps(body),
+        }
+
+    @patch("handler.boto3")
+    @patch.dict("os.environ", {"AWS_REGION": "us-east-1", "AGENT_RUNTIME_ARN": "arn:aws:test"})
+    def test_empty_agent_response_returns_422(self, mock_boto3):
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.invoke_agent_runtime.return_value = {"stream": []}
+
+        resp = handler(self._post({"location": "xyznonexistent", "analysisType": "NDVI"}), None)
+        self.assertEqual(resp["statusCode"], 422)
+        body = json.loads(resp["body"])
+        self.assertIn("xyznonexistent", body["message"])
+        self.assertIn("could not be found", body["message"])
+
+    @patch("handler.boto3")
+    @patch.dict("os.environ", {"AWS_REGION": "us-east-1", "AGENT_RUNTIME_ARN": "arn:aws:test"})
+    def test_could_not_find_location_returns_422(self, mock_boto3):
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.invoke_agent_runtime.return_value = {
+            "stream": [{"chunk": {"bytes": b"I could not find the specified location."}}]
+        }
+
+        resp = handler(self._post({"location": "Atlantis", "analysisType": "NDVI"}), None)
+        self.assertEqual(resp["statusCode"], 422)
+        body = json.loads(resp["body"])
+        self.assertIn("Atlantis", body["message"])
+
+    @patch("handler.boto3")
+    @patch.dict("os.environ", {"AWS_REGION": "us-east-1", "AGENT_RUNTIME_ARN": "arn:aws:test"})
+    def test_unable_to_locate_returns_422(self, mock_boto3):
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.invoke_agent_runtime.return_value = {
+            "stream": [{"chunk": {"bytes": b"Unable to locate the area you specified."}}]
+        }
+
+        resp = handler(self._post({"location": "Nowhere Land", "analysisType": "NBR"}), None)
+        self.assertEqual(resp["statusCode"], 422)
+
+    @patch("handler.boto3")
+    @patch.dict("os.environ", {"AWS_REGION": "us-east-1", "AGENT_RUNTIME_ARN": "arn:aws:test"})
+    def test_valid_response_not_flagged_as_invalid(self, mock_boto3):
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.invoke_agent_runtime.return_value = {
+            "stream": [{"chunk": {"bytes": b"NDVI analysis for Central Park shows healthy vegetation."}}]
+        }
+
+        resp = handler(self._post({"location": "Central Park", "analysisType": "NDVI"}), None)
+        self.assertEqual(resp["statusCode"], 200)
+
+
+class TestIsInvalidLocationResponse(unittest.TestCase):
+    """Unit tests for _is_invalid_location_response helper."""
+
+    def test_empty_string_is_invalid(self):
+        self.assertTrue(_is_invalid_location_response(""))
+
+    def test_none_is_invalid(self):
+        self.assertTrue(_is_invalid_location_response(None))
+
+    def test_whitespace_only_is_invalid(self):
+        self.assertTrue(_is_invalid_location_response("   "))
+
+    def test_could_not_find_is_invalid(self):
+        self.assertTrue(_is_invalid_location_response("I could not find that location."))
+
+    def test_invalid_location_is_invalid(self):
+        self.assertTrue(_is_invalid_location_response("The invalid location was provided."))
+
+    def test_normal_response_is_valid(self):
+        self.assertFalse(_is_invalid_location_response("NDVI analysis complete. Vegetation is healthy."))
+
+
+class TestMissingAnalysisTypeErrorMessage(unittest.TestCase):
+    """Verify missing/invalid analysisType error messages include valid options."""
+
+    def _post(self, body):
+        event = {"httpMethod": "POST", "resource": "/analyze"}
+        event["body"] = json.dumps(body)
+        return handler(event, None)
+
+    def test_missing_analysis_type_message(self):
+        resp = self._post({"location": "Central Park"})
+        self.assertEqual(resp["statusCode"], 400)
+        body = json.loads(resp["body"])
+        self.assertIn("analysisType", body["message"])
+
+    def test_invalid_analysis_type_lists_valid_options(self):
+        resp = self._post({"location": "Central Park", "analysisType": "FAKE"})
+        self.assertEqual(resp["statusCode"], 400)
+        body = json.loads(resp["body"])
+        for valid_type in VALID_ANALYSIS_TYPES:
+            self.assertIn(valid_type, body["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/api-cdk/lambda/worker.py
+++ b/api-cdk/lambda/worker.py
@@ -20,6 +20,66 @@ JOBS_TABLE_NAME = os.environ.get("JOBS_TABLE_NAME", "")
 dynamodb = boto3.resource("dynamodb")
 
 
+def _handle_mcp_tool_call(tool_name, arguments):
+    """Handle an individual MCP tool call by invoking the agent with a
+    tool-specific prompt. Returns the parsed result.
+
+    Each tool maps to a specific agent prompt that triggers the right
+    tool chain in the geospatial agent.
+    """
+    if tool_name == "search_places":
+        query = arguments.get("query", "")
+        prompt = f"Search for the location '{query}'. Return the coordinates, address, and place metadata. Return only the results, no explanatory text."
+        raw = _invoke_agent(prompt)
+        return {"tool": "search_places", "query": query, "result": raw}
+
+    elif tool_name == "find_location_boundary":
+        location = arguments.get("location", "")
+        prompt = f"Find the boundary polygon for '{location}'. Return the S3 URL of the GeoJSON boundary file. Return only the S3 URL, no explanatory text."
+        raw = _invoke_agent(prompt)
+        return {"tool": "find_location_boundary", "location": location, "result": raw}
+
+    elif tool_name == "get_rasters":
+        location = arguments.get("location", "")
+        geometry_url = arguments.get("geometry_s3_url", "")
+        date_str = arguments.get("current_date_str", "")
+        max_cloud = arguments.get("max_cloud", 30)
+        prompt = f"Get Sentinel-2 satellite imagery bands for '{location}'."
+        if geometry_url:
+            prompt += f" Use the boundary geometry at {geometry_url}."
+        if date_str:
+            prompt += f" Search from 60 days before {date_str} to {date_str}."
+        prompt += f" Maximum cloud coverage: {max_cloud}%. Return only the S3 URLs for each band, no explanatory text."
+        raw = _invoke_agent(prompt)
+        return {"tool": "get_rasters", "location": location, "result": raw}
+
+    elif tool_name == "run_bandmath":
+        location = arguments.get("location", "")
+        index_type = arguments.get("index_type", "NDVI")
+        band1_url = arguments.get("band1_url", "")
+        band2_url = arguments.get("band2_url", "")
+        date_str = arguments.get("date_str", "")
+        geometry_url = arguments.get("geometry_s3_url", "")
+        prompt = f"Calculate {index_type} for '{location}' using band1={band1_url} and band2={band2_url}."
+        if date_str:
+            prompt += f" Date: {date_str}."
+        if geometry_url:
+            prompt += f" Clip to geometry: {geometry_url}."
+        prompt += " Return the statistics (mean, median, class percentages) and S3 URL of the result raster. Return only the data, no explanatory text."
+        raw = _invoke_agent(prompt)
+        return {"tool": "run_bandmath", "index_type": index_type, "location": location, "result": raw}
+
+    elif tool_name == "display_visual":
+        s3_url = arguments.get("s3_url", "")
+        title = arguments.get("title", "")
+        description = arguments.get("description", "")
+        # display_visual is a visualization tool — just acknowledge it
+        return {"tool": "display_visual", "s3_url": s3_url, "title": title, "description": description, "result": "Visualization acknowledged"}
+
+    else:
+        raise ValueError(f"Unknown MCP tool: {tool_name}")
+
+
 def _update_job(job_id, status, result=None, error=None):
     """Update job record in DynamoDB."""
     table = dynamodb.Table(JOBS_TABLE_NAME)
@@ -46,19 +106,42 @@ def _update_job(job_id, status, result=None, error=None):
 
 
 def handler(event, context):
-    """Process an analysis job."""
+    """Process an analysis job or MCP tool call."""
     job_id = event.get("jobId")
     request = event.get("request", {})
 
+    # --- MCP tool call: invoke the agent with a tool-specific prompt ---
+    if request.get("mcp_tool_call"):
+        tool_name = request.get("tool_name", "")
+        arguments = request.get("arguments", {})
+        _update_job(job_id, "RUNNING")
+
+        try:
+            result = _handle_mcp_tool_call(tool_name, arguments)
+            _update_job(job_id, "COMPLETED", result=result)
+        except Exception as exc:
+            _update_job(job_id, "FAILED", error=f"Tool error: {str(exc)}")
+        return
+
+    # --- Standard analysis job ---
     location = request.get("location", "").strip()
     analysis_type = request.get("analysisType", "")
     date_range = request.get("dateRange")
+    user_prompt = request.get("prompt", "").strip()
 
     # Mark as running
     _update_job(job_id, "RUNNING")
 
     try:
-        prompt = _build_prompt(location, analysis_type, date_range)
+        if location:
+            prompt = _build_prompt(location, analysis_type, date_range)
+        elif user_prompt:
+            # No explicit location — build prompt from the user's natural language request.
+            # The agent's geocoding tools will extract place names.
+            prompt = f"{user_prompt} Perform {analysis_type} analysis. Return only the statistics and S3 URLs, no explanatory text."
+        else:
+            _update_job(job_id, "FAILED", error="No location or prompt provided")
+            return
         raw_response = _invoke_agent(prompt)
     except (ReadTimeoutError, ConnectTimeoutError):
         _update_job(job_id, "FAILED", error="Agent request timed out")
@@ -72,14 +155,98 @@ def handler(event, context):
 
     # Check for invalid location
     if _is_invalid_location_response(raw_response):
-        _update_job(job_id, "FAILED", error=f"Unable to process location '{location}'")
+        loc_desc = location if location else "(extracted from prompt)"
+        _update_job(job_id, "FAILED", error=f"Unable to process location '{loc_desc}'")
         return
 
     # Parse and enrich result
-    result = _parse_agent_response(raw_response, location, analysis_type)
+    result = _parse_agent_response(raw_response, location or "requested area", analysis_type)
 
-    for url_key, url_value in result["imageUrls"].items():
-        if url_value is not None:
+    # Convert TIF image URLs to browser-renderable PNGs.
+    # For TIF files: fetch a PNG preview via TiTiler, upload to S3, return presigned PNG URL.
+    # For other files (GeoJSON, etc.): skip — they're not renderable as images.
+    titiler_url = os.environ.get("TITILER_API_URL", "").rstrip("/")
+    titiler_api_key = os.environ.get("TITILER_API_KEY", "")
+    s3_client = boto3.client("s3")
+    s3_bucket = os.environ.get("S3_BUCKET_NAME", "")
+
+    for url_key in list(result["imageUrls"].keys()):
+        url_value = result["imageUrls"][url_key]
+        if url_value is None:
+            continue
+
+        lower_url = url_value.lower()
+
+        # Skip non-image files and raw band rasters that aren't useful standalone
+        if lower_url.endswith(".geojson") or lower_url.endswith(".json"):
+            result["imageUrls"][url_key] = None
+            continue
+        # Skip raw spectral bands (NIR, RED) — they're inputs to index calculations,
+        # not meaningful standalone images
+        basename = lower_url.split("/")[-1].split("?")[0]
+        if basename.startswith("nir_") or basename.startswith("red_"):
+            result["imageUrls"][url_key] = None
+            continue
+
+        if (lower_url.endswith(".tif") or lower_url.endswith(".tiff")) and titiler_url and s3_bucket:
+            try:
+                from urllib.parse import quote
+                presigned_tif = _generate_presigned_url(url_value)
+
+                # Build TiTiler preview URL with appropriate rendering params
+                # based on the image type (TCI vs index rasters)
+                titiler_params = f"url={quote(presigned_tif, safe='')}&max_size=512"
+
+                if "tci" in lower_url or "true_color" in lower_url or "truecolor" in lower_url:
+                    # True Color Image — 3-band RGB, just needs size constraint
+                    pass
+                elif "ndvi" in lower_url or "ndwi" in lower_url or "nbr" in lower_url:
+                    # Index raster — single band float, needs rescaling and colormap
+                    titiler_params += "&rescale=-1,1&colormap_name=rdylgn"
+                elif "nir" in lower_url or "red" in lower_url:
+                    # Raw band — single band, needs rescaling
+                    titiler_params += "&rescale=0,10000"
+                else:
+                    # Unknown raster — auto rescale
+                    titiler_params += "&rescale=0,10000"
+
+                titiler_preview_url = f"{titiler_url}/cog/preview.png?{titiler_params}"
+
+                import urllib.request
+                req = urllib.request.Request(titiler_preview_url)
+                if titiler_api_key:
+                    req.add_header("x-api-key", titiler_api_key)
+                with urllib.request.urlopen(req, timeout=30) as resp:
+                    raw_data = resp.read()
+
+                # TiTiler via API Gateway may return base64-encoded PNG
+                # Detect and decode if needed
+                import base64
+                if raw_data[:4] == b'\x89PNG':
+                    png_data = raw_data  # Already raw PNG
+                else:
+                    try:
+                        png_data = base64.b64decode(raw_data)
+                        if png_data[:4] != b'\x89PNG':
+                            raise ValueError("Decoded data is not PNG")
+                    except Exception:
+                        png_data = raw_data  # Use as-is, hope for the best
+
+                # Upload PNG to S3
+                png_key = url_value.replace("s3://", "").split("/", 1)[1] if "s3://" in url_value else url_value
+                png_key = png_key.rsplit(".", 1)[0] + ".png"
+                s3_client.put_object(
+                    Bucket=s3_bucket,
+                    Key=png_key,
+                    Body=png_data,
+                    ContentType="image/png",
+                )
+                result["imageUrls"][url_key] = _generate_presigned_url(f"s3://{s3_bucket}/{png_key}")
+            except Exception as e:
+                print(f"[Worker] TiTiler conversion failed for {url_key}: {e}")
+                # Fall back to presigned TIF URL
+                result["imageUrls"][url_key] = _generate_presigned_url(url_value)
+        else:
             result["imageUrls"][url_key] = _generate_presigned_url(url_value)
 
     _update_job(job_id, "COMPLETED", result=result)

--- a/api-cdk/lambda/worker.py
+++ b/api-cdk/lambda/worker.py
@@ -1,0 +1,85 @@
+"""Worker Lambda — invoked async, calls AgentCore, writes results to DynamoDB."""
+
+import json
+import os
+import time
+
+import boto3
+from botocore.exceptions import ReadTimeoutError, ConnectTimeoutError, ClientError
+
+# Import shared helpers from handler.py
+from handler import (
+    _build_prompt,
+    _invoke_agent,
+    _parse_agent_response,
+    _generate_presigned_url,
+    _is_invalid_location_response,
+)
+
+JOBS_TABLE_NAME = os.environ.get("JOBS_TABLE_NAME", "")
+dynamodb = boto3.resource("dynamodb")
+
+
+def _update_job(job_id, status, result=None, error=None):
+    """Update job record in DynamoDB."""
+    table = dynamodb.Table(JOBS_TABLE_NAME)
+    update_expr = "SET #s = :status, updatedAt = :now"
+    expr_values = {":status": status, ":now": int(time.time())}
+    expr_names = {"#s": "status"}
+
+    if result is not None:
+        update_expr += ", #r = :result"
+        expr_values[":result"] = result
+        expr_names["#r"] = "result"
+
+    if error is not None:
+        update_expr += ", #e = :error"
+        expr_values[":error"] = error
+        expr_names["#e"] = "error"
+
+    table.update_item(
+        Key={"jobId": job_id},
+        UpdateExpression=update_expr,
+        ExpressionAttributeValues=expr_values,
+        ExpressionAttributeNames=expr_names,
+    )
+
+
+def handler(event, context):
+    """Process an analysis job."""
+    job_id = event.get("jobId")
+    request = event.get("request", {})
+
+    location = request.get("location", "").strip()
+    analysis_type = request.get("analysisType", "")
+    date_range = request.get("dateRange")
+
+    # Mark as running
+    _update_job(job_id, "RUNNING")
+
+    try:
+        prompt = _build_prompt(location, analysis_type, date_range)
+        raw_response = _invoke_agent(prompt)
+    except (ReadTimeoutError, ConnectTimeoutError):
+        _update_job(job_id, "FAILED", error="Agent request timed out")
+        return
+    except ClientError as exc:
+        _update_job(job_id, "FAILED", error=f"AgentCore error: {str(exc)}")
+        return
+    except Exception as exc:
+        _update_job(job_id, "FAILED", error=f"Unexpected error: {str(exc)}")
+        return
+
+    # Check for invalid location
+    if _is_invalid_location_response(raw_response):
+        _update_job(job_id, "FAILED", error=f"Unable to process location '{location}'")
+        return
+
+    # Parse and enrich result
+    result = _parse_agent_response(raw_response, location, analysis_type)
+
+    for url_key, url_value in result["imageUrls"].items():
+        if url_value is not None:
+            result["imageUrls"][url_key] = _generate_presigned_url(url_value)
+
+    _update_job(job_id, "COMPLETED", result=result)

--- a/api-cdk/lib/api-stack.ts
+++ b/api-cdk/lib/api-stack.ts
@@ -1,0 +1,123 @@
+import * as cdk from 'aws-cdk-lib';
+import * as apigateway from 'aws-cdk-lib/aws-apigateway';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { Construct } from 'constructs';
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+
+dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
+
+export class ApiStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const agentRuntimeArn = process.env.AGENT_RUNTIME_ARN ?? '';
+    const s3BucketName = process.env.S3_BUCKET_NAME ?? '';
+
+    // --- DynamoDB table for job tracking ---
+    const jobsTable = new dynamodb.Table(this, 'GeoAgentJobsTable', {
+      tableName: 'geospatial-agent-jobs',
+      partitionKey: { name: 'jobId', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      timeToLiveAttribute: 'ttl',
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
+    // --- Worker Lambda (async — invoked by submit, runs up to 5 min) ---
+    const workerFn = new lambda.Function(this, 'GeoAgentWorkerFn', {
+      runtime: lambda.Runtime.PYTHON_3_12,
+      handler: 'worker.handler',
+      code: lambda.Code.fromAsset(path.join(__dirname, '..', 'lambda')),
+      timeout: cdk.Duration.minutes(5),
+      memorySize: 256,
+      environment: {
+        AGENT_RUNTIME_ARN: agentRuntimeArn,
+        S3_BUCKET_NAME: s3BucketName,
+        JOBS_TABLE_NAME: jobsTable.tableName,
+      },
+    });
+
+    jobsTable.grantReadWriteData(workerFn);
+
+    workerFn.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ['bedrock-agentcore:InvokeAgentRuntime'],
+        resources: agentRuntimeArn ? [agentRuntimeArn, `${agentRuntimeArn}/*`] : ['*'],
+      }),
+    );
+
+    workerFn.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ['s3:GetObject'],
+        resources: s3BucketName
+          ? [`arn:aws:s3:::${s3BucketName}/*`]
+          : ['arn:aws:s3:::*/*'],
+      }),
+    );
+
+    // --- API Lambda (sync — handles submit + poll + capabilities) ---
+    const apiFn = new lambda.Function(this, 'GeoAgentApiFn', {
+      runtime: lambda.Runtime.PYTHON_3_12,
+      handler: 'api.handler',
+      code: lambda.Code.fromAsset(path.join(__dirname, '..', 'lambda')),
+      timeout: cdk.Duration.seconds(10),
+      memorySize: 128,
+      environment: {
+        JOBS_TABLE_NAME: jobsTable.tableName,
+        WORKER_FUNCTION_NAME: workerFn.functionName,
+      },
+    });
+
+    jobsTable.grantReadWriteData(apiFn);
+    workerFn.grantInvoke(apiFn);
+
+    // --- API Gateway REST API ---
+    const api = new apigateway.RestApi(this, 'GeoAgentApi', {
+      restApiName: 'Geospatial Agent API',
+      description: 'Async REST API wrapper for the Geospatial Agent (Part 4)',
+      deployOptions: { stageName: 'prod' },
+    });
+
+    const apiKey = api.addApiKey('GeoAgentApiKey', {
+      apiKeyName: 'geospatial-agent-api-key',
+    });
+
+    const usagePlan = api.addUsagePlan('GeoAgentUsagePlan', {
+      name: 'GeospatialAgentUsagePlan',
+      throttle: { rateLimit: 10, burstLimit: 5 },
+    });
+    usagePlan.addApiKey(apiKey);
+    usagePlan.addApiStage({ stage: api.deploymentStage });
+
+    const lambdaIntegration = new apigateway.LambdaIntegration(apiFn);
+
+    // POST /analyze — submit a job
+    api.root.addResource('analyze').addMethod('POST', lambdaIntegration, {
+      apiKeyRequired: true,
+    });
+
+    // GET /jobs/{jobId} — poll for results
+    const jobsResource = api.root.addResource('jobs');
+    jobsResource.addResource('{jobId}').addMethod('GET', lambdaIntegration, {
+      apiKeyRequired: true,
+    });
+
+    // GET /capabilities — static metadata
+    api.root.addResource('capabilities').addMethod('GET', lambdaIntegration, {
+      apiKeyRequired: true,
+    });
+
+    // --- Outputs ---
+    new cdk.CfnOutput(this, 'ApiUrl', {
+      value: api.url,
+      description: 'API Gateway endpoint URL',
+    });
+
+    new cdk.CfnOutput(this, 'ApiKeyId', {
+      value: apiKey.keyId,
+      description: 'API Key ID (retrieve value via AWS CLI)',
+    });
+  }
+}

--- a/api-cdk/lib/api-stack.ts
+++ b/api-cdk/lib/api-stack.ts
@@ -16,6 +16,50 @@ export class ApiStack extends cdk.Stack {
     const agentRuntimeArn = process.env.AGENT_RUNTIME_ARN ?? '';
     const s3BucketName = process.env.S3_BUCKET_NAME ?? '';
 
+    // --- Add CORS to existing S3 bucket for browser image loading ---
+    if (s3BucketName) {
+      new cdk.custom_resources.AwsCustomResource(this, 'GeoAgentBucketCors', {
+        onCreate: {
+          service: 'S3',
+          action: 'putBucketCors',
+          parameters: {
+            Bucket: s3BucketName,
+            CORSConfiguration: {
+              CORSRules: [{
+                AllowedOrigins: ['*'],
+                AllowedMethods: ['GET', 'HEAD'],
+                AllowedHeaders: ['*'],
+                MaxAgeSeconds: 3600,
+              }],
+            },
+          },
+          physicalResourceId: cdk.custom_resources.PhysicalResourceId.of(`${s3BucketName}-cors`),
+        },
+        onUpdate: {
+          service: 'S3',
+          action: 'putBucketCors',
+          parameters: {
+            Bucket: s3BucketName,
+            CORSConfiguration: {
+              CORSRules: [{
+                AllowedOrigins: ['*'],
+                AllowedMethods: ['GET', 'HEAD'],
+                AllowedHeaders: ['*'],
+                MaxAgeSeconds: 3600,
+              }],
+            },
+          },
+          physicalResourceId: cdk.custom_resources.PhysicalResourceId.of(`${s3BucketName}-cors`),
+        },
+        policy: cdk.custom_resources.AwsCustomResourcePolicy.fromStatements([
+          new iam.PolicyStatement({
+            actions: ['s3:PutBucketCORS'],
+            resources: [`arn:aws:s3:::${s3BucketName}`],
+          }),
+        ]),
+      });
+    }
+
     // --- DynamoDB table for job tracking ---
     const jobsTable = new dynamodb.Table(this, 'GeoAgentJobsTable', {
       tableName: 'geospatial-agent-jobs',
@@ -36,6 +80,8 @@ export class ApiStack extends cdk.Stack {
         AGENT_RUNTIME_ARN: agentRuntimeArn,
         S3_BUCKET_NAME: s3BucketName,
         JOBS_TABLE_NAME: jobsTable.tableName,
+        TITILER_API_URL: process.env.TITILER_API_URL ?? '',
+        TITILER_API_KEY: process.env.TITILER_API_KEY ?? '',
       },
     });
 
@@ -50,19 +96,19 @@ export class ApiStack extends cdk.Stack {
 
     workerFn.addToRolePolicy(
       new iam.PolicyStatement({
-        actions: ['s3:GetObject'],
+        actions: ['s3:GetObject', 's3:PutObject'],
         resources: s3BucketName
           ? [`arn:aws:s3:::${s3BucketName}/*`]
           : ['arn:aws:s3:::*/*'],
       }),
     );
 
-    // --- API Lambda (sync — handles submit + poll + capabilities) ---
+    // --- API Lambda (sync — handles submit + poll + capabilities + MCP) ---
     const apiFn = new lambda.Function(this, 'GeoAgentApiFn', {
       runtime: lambda.Runtime.PYTHON_3_12,
       handler: 'api.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '..', 'lambda')),
-      timeout: cdk.Duration.seconds(10),
+      timeout: cdk.Duration.minutes(5),  // Increased: MCP tools/call waits for worker sync
       memorySize: 128,
       environment: {
         JOBS_TABLE_NAME: jobsTable.tableName,
@@ -84,11 +130,17 @@ export class ApiStack extends cdk.Stack {
       apiKeyName: 'geospatial-agent-api-key',
     });
 
+    // MCP API Key — separate key for MCP endpoint access by the mesh
+    const mcpApiKey = api.addApiKey('GeoAgentMcpApiKey', {
+      apiKeyName: 'geospatial-agent-mcp-api-key',
+    });
+
     const usagePlan = api.addUsagePlan('GeoAgentUsagePlan', {
       name: 'GeospatialAgentUsagePlan',
       throttle: { rateLimit: 10, burstLimit: 5 },
     });
     usagePlan.addApiKey(apiKey);
+    usagePlan.addApiKey(mcpApiKey);
     usagePlan.addApiStage({ stage: api.deploymentStage });
 
     const lambdaIntegration = new apigateway.LambdaIntegration(apiFn);
@@ -109,6 +161,77 @@ export class ApiStack extends cdk.Stack {
       apiKeyRequired: true,
     });
 
+    // POST /mcp — MCP JSON-RPC endpoint (API Gateway key required, same as other routes)
+    api.root.addResource('mcp').addMethod('POST', lambdaIntegration, {
+      apiKeyRequired: true,
+    });
+
+    // --- Store MCP API key value in SSM for the mesh to retrieve ---
+    // Uses a custom resource to read the API Gateway key value and write to SSM.
+    // This way the mesh can read the key from a known SSM path during supplier registration.
+    const mcpApiKeyRetriever = new cdk.custom_resources.AwsCustomResource(this, 'McpApiKeyToSsm', {
+      onCreate: {
+        service: 'APIGateway',
+        action: 'getApiKey',
+        parameters: {
+          apiKey: mcpApiKey.keyId,
+          includeValue: true,
+        },
+        physicalResourceId: cdk.custom_resources.PhysicalResourceId.of('mcp-api-key-retriever'),
+      },
+      onUpdate: {
+        service: 'APIGateway',
+        action: 'getApiKey',
+        parameters: {
+          apiKey: mcpApiKey.keyId,
+          includeValue: true,
+        },
+        physicalResourceId: cdk.custom_resources.PhysicalResourceId.of('mcp-api-key-retriever'),
+      },
+      policy: cdk.custom_resources.AwsCustomResourcePolicy.fromStatements([
+        new iam.PolicyStatement({
+          actions: ['apigateway:GET'],
+          resources: ['*'],
+        }),
+      ]),
+    });
+
+    const mcpApiKeyValue = mcpApiKeyRetriever.getResponseField('value');
+
+    // Write the MCP API key to SSM so the mesh can read it
+    new cdk.custom_resources.AwsCustomResource(this, 'McpApiKeySsmParam', {
+      onCreate: {
+        service: 'SSM',
+        action: 'putParameter',
+        parameters: {
+          Name: '/geospatial-agent/mcp-api-key',
+          Value: mcpApiKeyValue,
+          Type: 'SecureString',
+          Description: 'MCP API key for the Sentinel-2 geospatial agent — auto-managed by CDK',
+          Overwrite: true,
+        },
+        physicalResourceId: cdk.custom_resources.PhysicalResourceId.of('mcp-api-key-ssm'),
+      },
+      onUpdate: {
+        service: 'SSM',
+        action: 'putParameter',
+        parameters: {
+          Name: '/geospatial-agent/mcp-api-key',
+          Value: mcpApiKeyValue,
+          Type: 'SecureString',
+          Description: 'MCP API key for the Sentinel-2 geospatial agent — auto-managed by CDK',
+          Overwrite: true,
+        },
+        physicalResourceId: cdk.custom_resources.PhysicalResourceId.of('mcp-api-key-ssm'),
+      },
+      policy: cdk.custom_resources.AwsCustomResourcePolicy.fromStatements([
+        new iam.PolicyStatement({
+          actions: ['ssm:PutParameter'],
+          resources: [`arn:aws:ssm:${this.region}:${this.account}:parameter/geospatial-agent/mcp-api-key`],
+        }),
+      ]),
+    });
+
     // --- Outputs ---
     new cdk.CfnOutput(this, 'ApiUrl', {
       value: api.url,
@@ -118,6 +241,21 @@ export class ApiStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'ApiKeyId', {
       value: apiKey.keyId,
       description: 'API Key ID (retrieve value via AWS CLI)',
+    });
+
+    new cdk.CfnOutput(this, 'McpEndpointUrl', {
+      value: `${api.url}mcp`,
+      description: 'MCP endpoint URL for supplier registration',
+    });
+
+    new cdk.CfnOutput(this, 'McpApiKeyId', {
+      value: mcpApiKey.keyId,
+      description: 'MCP API Key ID (retrieve value via AWS CLI)',
+    });
+
+    new cdk.CfnOutput(this, 'McpApiKeySsmPath', {
+      value: '/geospatial-agent/mcp-api-key',
+      description: 'SSM path where the MCP API key is stored',
     });
   }
 }

--- a/api-cdk/package-lock.json
+++ b/api-cdk/package-lock.json
@@ -1,0 +1,699 @@
+{
+  "name": "geospatial-agent-api-cdk",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "geospatial-agent-api-cdk",
+      "version": "0.1.0",
+      "dependencies": {
+        "aws-cdk-lib": "2.189.1",
+        "constructs": "^10.0.0",
+        "dotenv": "^16.4.5",
+        "source-map-support": "^0.5.21"
+      },
+      "bin": {
+        "cdk-stack": "bin/app.js"
+      },
+      "devDependencies": {
+        "@types/node": "20.14.9",
+        "aws-cdk": "^2.189.1",
+        "ts-node": "^10.9.2",
+        "typescript": "~5.5.3"
+      }
+    },
+    "node_modules/@aws-cdk/asset-awscli-v1": {
+      "version": "2.2.275",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.275.tgz",
+      "integrity": "sha512-dyU4m8yH9vqVr+hm/MCiC5q3+nH6IX1wxABsAQX0qeyExmn+XNULMVpwa9HCLbYjeOgDSwTKJQ+CGDVY6Qu0OA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.1.tgz",
+      "integrity": "sha512-We4bmHaowOPHr+IQR4/FyTGjRfjgBj4ICMjtqmJeBDWad3Q/6St12NT07leNtyuukv2qMhtSZJQorD8KpKTwRA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "41.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-41.2.0.tgz",
+      "integrity": "sha512-JaulVS6z9y5+u4jNmoWbHZRs9uGOnmn/ktXygNWKNu1k6lF3ad4so3s18eRu15XCbUIomxN9WPYT6Ehh7hzONw==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "~1.4.1",
+        "semver": "^7.7.1"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.7.1",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.14.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
+      "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk": {
+      "version": "2.1118.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1118.0.tgz",
+      "integrity": "sha512-Tfd865GRewDTXIbTVtix/l+v8t3rZENvdHcQQZS2wXYVXfHzljULFXe9JKkgZUNDPB1zo9tSBUu8jjiHRm7nWg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "cdk": "bin/cdk"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib": {
+      "version": "2.189.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.189.1.tgz",
+      "integrity": "sha512-9JU0yUr2iRTJ1oCPrHyx7hOtBDWyUfyOcdb6arlumJnMcQr2cyAMASY8HuAXHc8Y10ipVp8dRTW+J4/132IIYA==",
+      "bundleDependencies": [
+        "@balena/dockerignore",
+        "case",
+        "fs-extra",
+        "ignore",
+        "jsonschema",
+        "minimatch",
+        "punycode",
+        "semver",
+        "table",
+        "yaml",
+        "mime-types"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/asset-awscli-v1": "^2.2.229",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
+        "@aws-cdk/cloud-assembly-schema": "^41.0.0",
+        "@balena/dockerignore": "^1.0.2",
+        "case": "1.6.3",
+        "fs-extra": "^11.3.0",
+        "ignore": "^5.3.2",
+        "jsonschema": "^1.5.0",
+        "mime-types": "^2.1.35",
+        "minimatch": "^3.1.2",
+        "punycode": "^2.3.1",
+        "semver": "^7.7.1",
+        "table": "^6.9.0",
+        "yaml": "1.10.2"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "constructs": "^10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/aws-cdk-lib/node_modules/ajv": {
+      "version": "8.17.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/astral-regex": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/case": {
+      "version": "1.6.3",
+      "inBundle": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/color-convert": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/color-name": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/concat-map": {
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-uri": {
+      "version": "3.0.6",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "inBundle": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fs-extra": {
+      "version": "11.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/aws-cdk-lib/node_modules/ignore": {
+      "version": "5.3.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonschema": {
+      "version": "1.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-db": {
+      "version": "1.52.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-types": {
+      "version": "2.1.35",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/minimatch": {
+      "version": "3.1.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/punycode": {
+      "version": "2.3.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/require-from-string": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/semver": {
+      "version": "7.7.1",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/string-width": {
+      "version": "4.2.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/table": {
+      "version": "6.9.0",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/universalify": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/yaml": {
+      "version": "1.10.2",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/constructs": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.6.0.tgz",
+      "integrity": "sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/api-cdk/package.json
+++ b/api-cdk/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "geospatial-agent-api-cdk",
+  "version": "0.1.0",
+  "description": "CDK stack for Geospatial Agent REST API wrapper",
+  "bin": {
+    "cdk-stack": "bin/app.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "cdk": "cdk",
+    "deploy": "cdk deploy",
+    "synth": "cdk synth",
+    "diff": "cdk diff",
+    "destroy": "cdk destroy"
+  },
+  "devDependencies": {
+    "@types/node": "20.14.9",
+    "aws-cdk": "^2.189.1",
+    "ts-node": "^10.9.2",
+    "typescript": "~5.5.3"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "2.189.1",
+    "constructs": "^10.0.0",
+    "dotenv": "^16.4.5",
+    "source-map-support": "^0.5.21"
+  }
+}

--- a/api-cdk/tsconfig.json
+++ b/api-cdk/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["es2020"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": ["./node_modules/@types"],
+    "resolveJsonModule": true,
+    "esModuleInterop": true
+  },
+  "exclude": ["node_modules", "cdk.out"]
+}

--- a/frontend-cdk/lib/geospatial-agent-stack.ts
+++ b/frontend-cdk/lib/geospatial-agent-stack.ts
@@ -38,7 +38,7 @@ export class GeospatialAgentStack extends cdk.Stack {
       s3BucketName: this.node.tryGetContext('s3BucketName') || process.env.S3_BUCKET_NAME,
 
       // AWS Region
-      awsRegion: this.node.tryGetContext('awsRegion') || process.env.AWS_REGION || 'us-east-1',
+      awsRegion: this.node.tryGetContext('awsRegion') || process.env.AWS_REGION || 'eu-central-1',
 
       // Admin user email for Cognito
       adminEmail: this.node.tryGetContext('adminEmail') || process.env.ADMIN_EMAIL,

--- a/geo_agent/.env.example
+++ b/geo_agent/.env.example
@@ -12,8 +12,8 @@ AGENTCORE_ARN=arn:aws:iam::YOUR_ACCOUNT_ID:role/agentcore-geospatial-agent-on-aw
 # OPTIONAL - Defaults work for most cases
 # ===========================================
 
-AWS_REGION=us-east-1
-MODEL_ID=us.anthropic.claude-sonnet-4-6
+AWS_REGION=eu-central-1
+MODEL_ID=eu.anthropic.claude-sonnet-4-6
 
 # ===========================================
 # LANGFUSE - Only needed for deploy_with_langfuse.sh

--- a/geo_agent/config.py
+++ b/geo_agent/config.py
@@ -14,10 +14,10 @@ S3_BUCKET_NAME = os.getenv("S3_BUCKET_NAME")
 if not S3_BUCKET_NAME:
     raise ValueError("S3_BUCKET_NAME environment variable is required")
 
-AWS_REGION = os.getenv("AWS_REGION", "us-east-1")
+AWS_REGION = os.getenv("AWS_REGION", "eu-central-1")
 
 # Bedrock Model Configuration
-MODEL_ID = os.getenv("MODEL_ID", "us.anthropic.claude-sonnet-4-6")
+MODEL_ID = os.getenv("MODEL_ID", "eu.anthropic.claude-sonnet-4-6")
 MODEL_TEMPERATURE = float(os.getenv("MODEL_TEMPERATURE", "0.1"))
 MODEL_COSTS = { #see here: https://aws.amazon.com/bedrock/pricing/
             "input": 0.003/1000,

--- a/geo_agent/deploy.sh
+++ b/geo_agent/deploy.sh
@@ -29,8 +29,8 @@ for var in "${required_vars[@]}"; do
 done
 
 # Set defaults for optional variables
-MODEL_ID="${MODEL_ID:-us.anthropic.claude-sonnet-4-6}"
-AWS_REGION="${AWS_REGION:-us-east-1}"
+MODEL_ID="${MODEL_ID:-eu.anthropic.claude-sonnet-4-6}"
+AWS_REGION="${AWS_REGION:-eu-central-1}"
 
 # Export region so agentcore CLI deploys to the correct region
 export AWS_REGION

--- a/geo_agent/deploy_with_langfuse.sh
+++ b/geo_agent/deploy_with_langfuse.sh
@@ -31,8 +31,8 @@ done
 echo "🚀 Deploying AgentCore agent with Langfuse observability..."
 
 # Set defaults for optional variables
-BEDROCK_MODEL_ID="${MODEL_ID:-us.anthropic.claude-sonnet-4-6}"
-AWS_REGION="${AWS_REGION:-us-east-1}"
+BEDROCK_MODEL_ID="${MODEL_ID:-eu.anthropic.claude-sonnet-4-6}"
+AWS_REGION="${AWS_REGION:-eu-central-1}"
 
 # Build Basic Auth header for OTEL
 LANGFUSE_AUTH=$(echo -n "${LANGFUSE_PUBLIC_KEY}:${LANGFUSE_SECRET_KEY}" | base64)

--- a/geo_agent/geospatial_agent_on_aws.py
+++ b/geo_agent/geospatial_agent_on_aws.py
@@ -33,6 +33,7 @@ app = BedrockAgentCoreApp()
 
 bedrock_model = BedrockModel(
     model_id=config.MODEL_ID,
+    region_name=config.AWS_REGION,
     temperature=config.MODEL_TEMPERATURE,
 )
     


### PR DESCRIPTION
Adds an async REST API (API Gateway + Lambda + DynamoDB) that wraps the AgentCore geospatial agent behind a stable contract boundary.

- POST /analyze: submit analysis job, returns job ID immediately
- GET /jobs/{jobId}: poll for status and results
- GET /capabilities: list available analysis types
- API key authentication, no timeout constraints
- Worker Lambda invokes AgentCore async (up to 5 min)
- DynamoDB job table with 24h TTL
- One-command deploy via deploy.sh
- Updated README with Part 4 deployment guide and API contract

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
