### PR TITLE
fix: conditionally disable ADOT for clean Langfuse traces

### DIFF
--- a/geo_agent/Dockerfile
+++ b/geo_agent/Dockerfile
@@ -78,4 +78,4 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
 # Copy project files
 COPY . .
 
-CMD ["opentelemetry-instrument", "python", "-m", "geospatial_agent_on_aws"]
+CMD if [ "$DISABLE_ADOT_OBSERVABILITY" = "true" ]; then exec python -m geospatial_agent_on_aws; else exec opentelemetry-instrument python -m geospatial_agent_on_aws; fi

--- a/geo_agent/Dockerfile_geospatial_agent_on_aws
+++ b/geo_agent/Dockerfile_geospatial_agent_on_aws
@@ -78,4 +78,4 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
 # Copy project files
 COPY . .
 
-CMD ["opentelemetry-instrument", "python", "-m", "geospatial_agent_on_aws"]
+CMD if [ "$DISABLE_ADOT_OBSERVABILITY" = "true" ]; then exec python -m geospatial_agent_on_aws; else exec opentelemetry-instrument python -m geospatial_agent_on_aws; fi


### PR DESCRIPTION
## Problem

When deploying with Langfuse observability, the `opentelemetry-instrument` wrapper (ADOT auto-instrumentation) creates noisy traces:
- Every `GET /ping` health check (every 2s) appears as a separate trace
- Each streaming chunk creates its own HTTP span
- Traces are fragmented instead of showing a single coherent agent invocation

## Fix

Make the Dockerfile CMD conditional on `DISABLE_ADOT_OBSERVABILITY` env var:
- When `true`: run `python -m geospatial_agent_on_aws` directly — only Strands StrandsTelemetry OTLP exporter sends traces to Langfuse
- When unset/false: use `opentelemetry-instrument` wrapper as before for ADOT/CloudWatch observability

The `deploy_with_langfuse.sh` script already passes `DISABLE_ADOT_OBSERVABILITY=true` — this change makes the Dockerfile actually respect it.

## Testing

- Deployed with Langfuse enabled → clean single-trace-per-invocation in Langfuse dashboard
- No more /ping spam or per-chunk traces
- Non-Langfuse deployments (deploy.sh) continue using ADOT as before