### PR TITLE
Sub-region scans + change-detection performance pass

### DIFF
--- a/frontend-cdk/bin/app.ts
+++ b/frontend-cdk/bin/app.ts
@@ -32,7 +32,9 @@ const stack = new GeospatialAgentStack(app, stackName, {
 // Deploy separately (`cdk deploy ChangeDetectionStack`) and set
 // LGND_EMBEDDINGS_ENABLED=true on the agent runtime to enable the feature.
 new ChangeDetectionStack(app, 'ChangeDetectionStack', {
-  env,
+  // Deploy in the LGND data region (us-west-2) so the Lambda's parquet reads are
+  // local rather than cross-region. Override with LGND_LAMBDA_REGION if needed.
+  env: { account: env.account, region: process.env.LGND_LAMBDA_REGION || 'us-west-2' },
   description: 'Optional LGND embedding Lambda for region-wide change scan',
   tags: {
     Project: 'GeospatialAgent',

--- a/frontend-cdk/lib/change-detection-stack.ts
+++ b/frontend-cdk/lib/change-detection-stack.ts
@@ -36,7 +36,7 @@ export class ChangeDetectionStack extends cdk.Stack {
       code: lambda.DockerImageCode.fromImageAsset(
         path.join(__dirname, '..', '..', 'geo_agent', 'lambda_functions', 'lgnd_query'),
       ),
-      timeout: cdk.Duration.seconds(300),
+      timeout: cdk.Duration.seconds(120),
       memorySize: 2048,
       architecture: lambda.Architecture.X86_64,
       description: `LGND embedding partition query for region-wide change scan (${environment})`,

--- a/geo_agent/Dockerfile_geospatial_agent_on_aws
+++ b/geo_agent/Dockerfile_geospatial_agent_on_aws
@@ -72,6 +72,20 @@ ENV DOCKER_CONTAINER=1
 ENV GDAL_CACHEMAX=256
 ENV GDAL_NUM_THREADS=2
 
+# Speed up Cloud-Optimized GeoTIFF reads over HTTP (/vsicurl). Without these,
+# GDAL issues extra directory-listing/probe requests on every COG open, which
+# adds seconds to each band clip, CRS probe, and change-detection read.
+#   - DISABLE_READDIR_ON_OPEN: skip the per-open directory listing (biggest win)
+#   - allowed extensions: don't probe for sidecar files, only GeoTIFFs
+#   - HTTP/2 multiplexing + range caching for fewer, faster round-trips
+ENV GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR
+ENV CPL_VSIL_CURL_ALLOWED_EXTENSIONS=.tif,.tiff,.TIF,.TIFF
+ENV GDAL_HTTP_MULTIPLEX=YES
+ENV GDAL_HTTP_VERSION=2
+ENV VSI_CACHE=TRUE
+ENV VSI_CACHE_SIZE=67108864
+ENV GDAL_INGESTED_BYTES_AT_OPEN=32768
+
 # Create non-root user
 RUN useradd -m -u 1000 bedrock_agentcore
 USER bedrock_agentcore

--- a/geo_agent/agentcore_utils/helper_funcs.py
+++ b/geo_agent/agentcore_utils/helper_funcs.py
@@ -18,6 +18,9 @@ def create_agentcore_role(agent_name: str, s3_bucket_name: str, region: str = No
         region = os.environ.get('AWS_DEFAULT_REGION') or os.environ.get('AWS_REGION') or Session().region_name
     
     account_id = boto3.client("sts").get_caller_identity()["Account"]
+    # Region where the lgnd-partition-query Lambda is deployed (LGND data
+    # region by default) so the invoke grant ARN targets the right function.
+    lgnd_lambda_region = os.environ.get("LGND_LAMBDA_REGION", "us-west-2")
     role_policy = {
         "Version": "2012-10-17",
         "Statement": [
@@ -144,7 +147,7 @@ def create_agentcore_role(agent_name: str, s3_bucket_name: str, region: str = No
                 "Sid": "LambdaInvokeForChangeDetection",
                 "Effect": "Allow",
                 "Action": "lambda:InvokeFunction",
-                "Resource": f"arn:aws:lambda:{region}:{account_id}:function:lgnd-partition-query"
+                "Resource": f"arn:aws:lambda:{lgnd_lambda_region}:{account_id}:function:lgnd-partition-query"
 		    }
         ]
     }

--- a/geo_agent/config.py
+++ b/geo_agent/config.py
@@ -58,7 +58,8 @@ GEOMETRY WORKFLOW:
 PARALLELIZATION STRATEGY:
 ✅ **ALWAYS PARALLEL:**
 - Geocoding: search_places + find_location_boundary
-- Multi-date rasters: get_rasters(date1) + get_rasters(date2) + get_rasters(date3)
+- Two-date comparison (change detection): get_rasters_for_dates(date1, date2) — fetches both in ONE parallel call
+- Multi-date rasters (3+): get_rasters(date1) + get_rasters(date2) + get_rasters(date3)
 - Multi-date analysis: run_bandmath(date1) + run_bandmath(date2) after all rasters retrieved
 - Multiple display_visual calls for different results
 
@@ -186,6 +187,7 @@ TOOLS:
 - search_places, find_location_boundary, get_best_geometry: Geocoding and boundary retrieval
 - create_bbox_from_coordinates: Handle user-drawn GeoJSON (Point→2km bbox, Polygon→as-is)
 - get_rasters: Retrieve satellite imagery (returns red, green, nir, nir08, swir2, tci, date_used)
+- get_rasters_for_dates: Fetch imagery for TWO dates IN PARALLEL — use for change detection / before-after comparisons instead of two get_rasters calls
 - run_bandmath: Calculate indices (returns area_m2 per class + percentages + result_s3_url)
 - scan_region_change: Country/region-wide change hotspot detection using Clay AI embeddings. Fast (seconds), covers entire countries at 1.28km resolution. Returns ranked hotspot locations for drill-in.
 - run_change_detection: Multi-index + iMAD change detection between two dates (returns change_map_s3_url + imad_change_map_s3_url + per-class areas). Requires band URLs from TWO get_rasters calls.
@@ -234,7 +236,7 @@ User: "Show me the NDVI for Hyde Park again"
 **Change Detection (Land Clearing / Construction / Development):**
 User: "What land changes happened near Manaus, Brazil between 2023 and 2025?"
 1. Get geometry → display_visual
-2. PARALLEL: get_rasters(date="2023-06-01") + get_rasters(date="2025-06-01")
+2. get_rasters_for_dates(location, date1_str="2023-06-01", date2_str="2025-06-01", geometry_s3_url) — fetches BOTH dates in parallel
 3. Display both TCIs
 4. run_change_detection(location, red/nir/green URLs from both dates, date1, date2, geometry_s3_url, nir08/swir2 URLs)
 5. display_visual(change_map_s3_url) — renders green-yellow-red spectral change map

--- a/geo_agent/config.py
+++ b/geo_agent/config.py
@@ -114,6 +114,18 @@ Choose the tool by the SIZE of the area, NOT just the user's wording. The phrase
 - **A specific small area (≲100 km²: a city, neighborhood, park, fire scar, construction site,
   or a hotspot returned by a prior scan)** → run_change_detection for pixel-level detail.
 
+- **A NAMED SUB-REGION of a state/country (a valley, county, metro area, mountain range,
+  basin, national forest, watershed - e.g. "San Luis Valley, Colorado", "Denver metro",
+  "San Juan Mountains") is NOT the whole state. Do NOT pass the parent state/country name
+  to scan_region_change - that scans the entire state.** Instead:
+  1. Geocode the sub-region first: find_location_boundary + get_best_geometry.
+  2. If it is ≲ 5,000 km² → run_change_detection (pixel-level) on that geometry.
+  3. If it is larger → call scan_region_change with geometry_s3_url set to the geocoded
+     geometry (NOT a region name); the scan then covers only that area.
+  Example - "Scan San Luis Valley, Colorado for change 2019→2024": geocode San Luis
+  Valley, then scan_region_change(region="San Luis Valley, Colorado", ..., geometry_s3_url=<geom>).
+  Never scan all of Colorado for this request.
+
 - Typical workflow: scan_region_change (find hotspots across the region) → user picks a hotspot
   → run_change_detection (pixel-level detail on that spot).
 

--- a/geo_agent/config.py
+++ b/geo_agent/config.py
@@ -117,14 +117,16 @@ Choose the tool by the SIZE of the area, NOT just the user's wording. The phrase
 - **A NAMED SUB-REGION of a state/country (a valley, county, metro area, mountain range,
   basin, national forest, watershed - e.g. "San Luis Valley, Colorado", "Denver metro",
   "San Juan Mountains") is NOT the whole state. Do NOT pass the parent state/country name
-  to scan_region_change - that scans the entire state.** Instead:
-  1. Geocode the sub-region first: find_location_boundary + get_best_geometry.
-  2. If it is ≲ 5,000 km² → run_change_detection (pixel-level) on that geometry.
-  3. If it is larger → call scan_region_change with geometry_s3_url set to the geocoded
-     geometry (NOT a region name); the scan then covers only that area.
-  Example - "Scan San Luis Valley, Colorado for change 2019→2024": geocode San Luis
-  Valley, then scan_region_change(region="San Luis Valley, Colorado", ..., geometry_s3_url=<geom>).
-  Never scan all of Colorado for this request.
+  to scan_region_change - that scans the entire state and is wrong.** Instead:
+  1. Determine the sub-region's approximate extent as bbox=[west, south, east, north] in
+     degrees - use your geographic knowledge of the named area, or geocode it.
+  2. If that extent is ≲ 5,000 km² → run_change_detection (pixel-level) on it.
+  3. Otherwise → scan_region_change(region="<name>", year1, month1, year2, month2,
+     bbox=[west, south, east, north]). The scan then covers ONLY that area.
+  Example - "Scan San Luis Valley, Colorado for change 2019→2024": the valley is roughly
+  bbox=[-106.5, 37.0, -105.0, 38.1]; call scan_region_change(region="San Luis Valley,
+  Colorado", year1=2019, month1=7, year2=2024, month2=7, bbox=[-106.5, 37.0, -105.0, 38.1]).
+  NEVER scan all of Colorado for this request.
 
 - Typical workflow: scan_region_change (find hotspots across the region) → user picks a hotspot
   → run_change_detection (pixel-level detail on that spot).

--- a/geo_agent/config.py
+++ b/geo_agent/config.py
@@ -259,6 +259,12 @@ MAX_CUSTOM_AREA_SIZE_KM2 = int(os.getenv("MAX_CUSTOM_AREA_SIZE_KM2", "100"))
 # covered — such requests are rejected and routed to scan_region_change.
 # A city/metro/county fits comfortably; a state/country does not.
 MAX_CHANGE_DETECTION_AREA_KM2 = int(os.getenv("MAX_CHANGE_DETECTION_AREA_KM2", "5000"))
+
+# Downsample factor for pixel-level run_change_detection. Bands are read at
+# 1/N resolution (averaged), cutting read + iMAD cost ~N^2 with negligible
+# visual impact (change maps are displayed downsampled anyway). Only applied to
+# larger AOIs; small clips stay full resolution. Set to 1 to disable.
+CHANGE_DETECTION_DOWNSAMPLE = int(os.getenv("CHANGE_DETECTION_DOWNSAMPLE", "2"))
 DEFAULT_MAX_CLOUD_COVERAGE = int(os.getenv("DEFAULT_MAX_CLOUD_COVERAGE", "30"))
 FALLBACK_MAX_CLOUD_COVERAGE = int(os.getenv("FALLBACK_MAX_CLOUD_COVERAGE", "80"))
 SATELLITE_BANDS = ["red", "nir"]

--- a/geo_agent/deploy.sh
+++ b/geo_agent/deploy.sh
@@ -61,7 +61,8 @@ agentcore configure \
     --ecr ${ECR_REPO_NAME} \
     --execution-role "${AGENTCORE_ARN}" \
     --disable-memory \
-    --disable-otel
+    --disable-otel \
+    --non-interactive
 
 # Restore Dockerfile
 cp Dockerfile_geospatial_agent_on_aws Dockerfile

--- a/geo_agent/geospatial_agent_on_aws.py
+++ b/geo_agent/geospatial_agent_on_aws.py
@@ -30,7 +30,7 @@ from strands.session.s3_session_manager import S3SessionManager
 
 
 from utils.tools import (find_location_boundary, create_bbox_from_coordinates,
-                         get_best_geometry, get_rasters, run_bandmath,
+                         get_best_geometry, get_rasters, get_rasters_for_dates, run_bandmath,
                          display_visual, calculator, list_session_assets, calculate_environmental_impact,
                          run_change_detection, scan_region_change)
 from utils.scenario_loader import load_scenario, build_scenario_context
@@ -145,7 +145,7 @@ async def sat_image_analyzer_agent(payload, context=None):
             # Create agent with session manager, cached system prompt and langfuse trace attributes
             agent = Agent(
                 tools=mcp_tools + [find_location_boundary, create_bbox_from_coordinates,
-                                    get_best_geometry, get_rasters, run_bandmath, 
+                                    get_best_geometry, get_rasters, get_rasters_for_dates, run_bandmath, 
                                     display_visual, calculator, list_session_assets, 
                                     calculate_environmental_impact,
                                    run_change_detection]

--- a/geo_agent/lambda_functions/lgnd_query/handler.py
+++ b/geo_agent/lambda_functions/lgnd_query/handler.py
@@ -94,39 +94,37 @@ def handler(event, context):
         # Index period 2 by cell_id
         d2_map = {row[0]: (row[1], row[2]) for row in rows2}
 
-        # Compute cosine similarity for matched cells
+        # Match cells present in both periods, then compute cosine similarity for
+        # all matched cells at once (vectorized) instead of a per-cell Python loop.
+        common = [row[0] for row in rows1 if row[0] in d2_map]
+        matched = len(common)
         changed_cells = []
-        matched = 0
 
-        for row in rows1:
-            cell_id = row[0]
-            if cell_id not in d2_map:
-                continue
-            matched += 1
+        if common:
+            d1_map = {row[0]: row[1] for row in rows1}
+            A = np.asarray([d1_map[c] for c in common], dtype=np.float32)
+            B = np.asarray([d2_map[c][0] for c in common], dtype=np.float32)
 
-            emb1 = np.array(row[1], dtype=np.float32)
-            emb2 = np.array(d2_map[cell_id][0], dtype=np.float32)
-            cell_bbox = d2_map[cell_id][1]
+            nA = np.linalg.norm(A, axis=1)
+            nB = np.linalg.norm(B, axis=1)
+            denom = nA * nB
+            valid = denom > 0
 
-            norm1 = np.linalg.norm(emb1)
-            norm2 = np.linalg.norm(emb2)
-            if norm1 == 0 or norm2 == 0:
-                continue
+            sims = np.zeros(matched, dtype=np.float32)
+            sims[valid] = np.sum(A[valid] * B[valid], axis=1) / denom[valid]
 
-            sim = float(np.dot(emb1, emb2) / (norm1 * norm2))
+            scores = np.clip((SIM_HIGH - sims) / SIM_RANGE, 0.0, 1.0)
 
-            # Skip likely cloud/snow/nodata artifacts (degenerate embeddings)
-            if sim < ARTIFACT_SIM_FLOOR:
-                continue
-
-            change_score = float(np.clip((SIM_HIGH - sim) / SIM_RANGE, 0.0, 1.0))
-
-            if change_score >= min_change_score:
+            # Keep only real change: valid embeddings, above the artifact floor,
+            # and over the change-score threshold.
+            keep = valid & (sims >= ARTIFACT_SIM_FLOOR) & (scores >= min_change_score)
+            for i in np.nonzero(keep)[0]:
+                cid = common[i]
                 changed_cells.append({
-                    "cell_id": cell_id,
-                    "change_score": round(change_score, 4),
-                    "similarity": round(sim, 4),
-                    "bbox": cell_bbox,
+                    "cell_id": cid,
+                    "change_score": round(float(scores[i]), 4),
+                    "similarity": round(float(sims[i]), 4),
+                    "bbox": d2_map[cid][1],
                 })
 
         return {

--- a/geo_agent/lambda_functions/lgnd_query/handler.py
+++ b/geo_agent/lambda_functions/lgnd_query/handler.py
@@ -35,7 +35,6 @@ Output:
 """
 import json
 import duckdb
-import numpy as np
 
 
 MONTHLY_PATH = "s3://us-west-2.opendata.source.coop/clay/lgnd-embeddings/monthly-aggregated"
@@ -81,57 +80,68 @@ def handler(event, context):
     bbox_filter = f"WHERE bbox.xmin <= {east} AND bbox.xmax >= {west} AND bbox.ymin <= {north} AND bbox.ymax >= {south}"
 
     try:
-        # Query period 1
-        path1 = f"{MONTHLY_PATH}/model_version={DEFAULT_MODEL_VERSION}/collection={DEFAULT_COLLECTION}/chip_size={DEFAULT_CHIP_SIZE}/dims={DEFAULT_DIMS}/geohash={gh}/year={year1}/month={month1:02d}/*.parquet"
-        rows1 = con.execute(f"SELECT cell_id, embedding FROM read_parquet('{path1}', hive_partitioning=true) {bbox_filter}").fetchall()
+        base = (f"{MONTHLY_PATH}/model_version={DEFAULT_MODEL_VERSION}"
+                f"/collection={DEFAULT_COLLECTION}/chip_size={DEFAULT_CHIP_SIZE}"
+                f"/dims={DEFAULT_DIMS}/geohash={gh}")
+        path1 = f"{base}/year={year1}/month={month1:02d}/*.parquet"
+        path2 = f"{base}/year={year2}/month={month2:02d}/*.parquet"
 
-        # Query period 2 (with bbox for output)
-        path2 = f"{MONTHLY_PATH}/model_version={DEFAULT_MODEL_VERSION}/collection={DEFAULT_COLLECTION}/chip_size={DEFAULT_CHIP_SIZE}/dims={DEFAULT_DIMS}/geohash={gh}/year={year2}/month={month2:02d}/*.parquet"
-        rows2 = con.execute(f"SELECT cell_id, embedding, bbox FROM read_parquet('{path2}', hive_partitioning=true) {bbox_filter}").fetchall()
+        # Cell counts. Reads only the cell_id column (parquet column pruning), so
+        # this stays cheap and never materializes embeddings.
+        counts = con.execute(f"""
+            WITH d1 AS (SELECT cell_id FROM read_parquet('{path1}', hive_partitioning=true) {bbox_filter}),
+                 d2 AS (SELECT cell_id FROM read_parquet('{path2}', hive_partitioning=true) {bbox_filter})
+            SELECT (SELECT count(*) FROM d1),
+                   (SELECT count(*) FROM d2),
+                   (SELECT count(*) FROM d1 JOIN d2 USING (cell_id))
+        """).fetchone()
+        total_d1, total_d2, matched = int(counts[0]), int(counts[1]), int(counts[2])
+
+        # Change detection. Cosine similarity is computed INSIDE DuckDB via
+        # list_cosine_similarity, so the 256-dim embeddings never cross into
+        # Python -- only cells past the artifact floor + change threshold come
+        # back. This keeps the function fast and bounds peak memory (the previous
+        # per-cell numpy approach materialized every embedding and peaked near the
+        # memory limit on dense partitions).
+        rows = con.execute(f"""
+            WITH d1 AS (
+                SELECT cell_id, embedding AS e1
+                FROM read_parquet('{path1}', hive_partitioning=true) {bbox_filter}
+            ),
+            d2 AS (
+                SELECT cell_id, embedding AS e2, bbox
+                FROM read_parquet('{path2}', hive_partitioning=true) {bbox_filter}
+            ),
+            sims AS (
+                SELECT d1.cell_id AS cell_id,
+                       list_cosine_similarity(d1.e1, d2.e2) AS sim,
+                       d2.bbox AS bbox
+                FROM d1 JOIN d2 USING (cell_id)
+            )
+            SELECT cell_id, sim, bbox,
+                   greatest(0.0, least(1.0, ({SIM_HIGH} - sim) / {SIM_RANGE})) AS change_score
+            FROM sims
+            WHERE sim >= {ARTIFACT_SIM_FLOOR}
+              AND greatest(0.0, least(1.0, ({SIM_HIGH} - sim) / {SIM_RANGE})) >= {min_change_score}
+        """).fetchall()
 
         con.close()
 
-        # Index period 2 by cell_id
-        d2_map = {row[0]: (row[1], row[2]) for row in rows2}
-
-        # Match cells present in both periods, then compute cosine similarity for
-        # all matched cells at once (vectorized) instead of a per-cell Python loop.
-        common = [row[0] for row in rows1 if row[0] in d2_map]
-        matched = len(common)
-        changed_cells = []
-
-        if common:
-            d1_map = {row[0]: row[1] for row in rows1}
-            A = np.asarray([d1_map[c] for c in common], dtype=np.float32)
-            B = np.asarray([d2_map[c][0] for c in common], dtype=np.float32)
-
-            nA = np.linalg.norm(A, axis=1)
-            nB = np.linalg.norm(B, axis=1)
-            denom = nA * nB
-            valid = denom > 0
-
-            sims = np.zeros(matched, dtype=np.float32)
-            sims[valid] = np.sum(A[valid] * B[valid], axis=1) / denom[valid]
-
-            scores = np.clip((SIM_HIGH - sims) / SIM_RANGE, 0.0, 1.0)
-
-            # Keep only real change: valid embeddings, above the artifact floor,
-            # and over the change-score threshold.
-            keep = valid & (sims >= ARTIFACT_SIM_FLOOR) & (scores >= min_change_score)
-            for i in np.nonzero(keep)[0]:
-                cid = common[i]
-                changed_cells.append({
-                    "cell_id": cid,
-                    "change_score": round(float(scores[i]), 4),
-                    "similarity": round(float(sims[i]), 4),
-                    "bbox": d2_map[cid][1],
-                })
+        changed_cells = [
+            {
+                "cell_id": r[0],
+                "change_score": round(float(r[3]), 4),
+                "similarity": round(float(r[1]), 4),
+                "bbox": r[2],
+            }
+            for r in rows
+        ]
 
         return {
             "statusCode": 200,
             "changed_cells": changed_cells,
-            "total_d1": len(rows1),
-            "total_d2": len(rows2),
+            "total_d1": total_d1,
+            "total_d2": total_d2,
             "matched": matched,
             "above_threshold": len(changed_cells),
             "geohash": gh,

--- a/geo_agent/utils/lgnd_embeddings.py
+++ b/geo_agent/utils/lgnd_embeddings.py
@@ -339,7 +339,10 @@ def _scan_with_lambda_fanout(
     from concurrent.futures import ThreadPoolExecutor, as_completed
 
     west, south, east, north = bbox
-    lambda_client = boto3.client('lambda', region_name='us-east-1')
+    # The lgnd-partition-query Lambda is deployed in the LGND data region
+    # (us-west-2) so its parquet reads are local. Configurable via env.
+    lambda_region = os.environ.get('LGND_LAMBDA_REGION', 'us-west-2')
+    lambda_client = boto3.client('lambda', region_name=lambda_region)
 
     print(f"🚀 Scanning {len(geohashes)} partitions via Lambda fan-out (parallel)...")
 

--- a/geo_agent/utils/sentinel_utils.py
+++ b/geo_agent/utils/sentinel_utils.py
@@ -249,36 +249,46 @@ def get_filtered_images(aoi_gdf, bands=["red", "nir"], max_cloud=30, current_dat
         # Clean location name for filename
         clean_location = location.replace(" ", "_").replace(",", "").lower() if location else "unknown"
         
-        # Clip and upload TCI (crop to AOI geometry)
-        tci_temp = f"{temp_dir}/tci_clipped_{clean_location}_{image_date}.tif"
-        clip_raster_v2(aoi_path, f"/vsicurl/{best_image['tci']}", tci_temp, crop_to_aoi=True)
-        
-        tci_s3_key = f"session_data/{session_id}/rasters/tci_clipped_{clean_location}_{image_date}.tif"
-        s3_client.upload_file(tci_temp, bucket_name, tci_s3_key)
-        
+        # Clip + upload the TCI and every requested band. Each layer is an
+        # independent HTTP COG read + S3 upload (I/O bound), so run them in
+        # parallel instead of sequentially -- this is the dominant cost of
+        # get_rasters (previously ~15s for ~7 layers done one at a time).
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
+        layers = [("tci", best_image["tci"])]
+        if bands:
+            layers += [(b, best_image[b]) for b in bands if b in best_image]
+
+        def _clip_and_upload(name, href):
+            local = f"{temp_dir}/{name}_clipped_{clean_location}_{image_date}.tif"
+            clip_raster_v2(aoi_path, f"/vsicurl/{href}", local, crop_to_aoi=True)
+            key = f"session_data/{session_id}/rasters/{name}_clipped_{clean_location}_{image_date}.tif"
+            s3_client.upload_file(local, bucket_name, key)
+            return name, f"s3://{bucket_name}/{key}"
+
+        uploaded = {}
+        with ThreadPoolExecutor(max_workers=min(len(layers), 8)) as ex:
+            futures = {ex.submit(_clip_and_upload, n, h): n for n, h in layers}
+            for fut in as_completed(futures):
+                name, url = fut.result()
+                uploaded[name] = url
+
         result = {
             "tci": best_image['tci'],
-            "tci_s3_url": f"s3://{bucket_name}/{tci_s3_key}",
+            "tci_s3_url": uploaded["tci"],
             "thumbnail": best_image['thumbnail'],
             "cloud_pct": best_image.get('cloud_pct', 'N/A'),
             "date": best_image.get('date', 'Unknown date'),
             "tile_id": best_image.get('tile_id', 'Unknown tile ID'),
             "coverage_pct": best_image.get('coverage_pct', 'N/A')
         }
-        
-        # Process bands (crop to AOI geometry)
+
         if bands:
             for band in bands:
-                if band in best_image:
-                    band_temp = f"{temp_dir}/{band}_clipped_{clean_location}_{image_date}.tif"
-                    clip_raster_v2(aoi_path, f"/vsicurl/{best_image[band]}", band_temp, crop_to_aoi=True)
-                    
-                    band_s3_key = f"session_data/{session_id}/rasters/{band}_clipped_{clean_location}_{image_date}.tif"
-                    s3_client.upload_file(band_temp, bucket_name, band_s3_key)
-                    
-                    result[f'{band}_s3_url'] = f"s3://{bucket_name}/{band_s3_key}"
+                if band in best_image and band in uploaded:
+                    result[f'{band}_s3_url'] = uploaded[band]
                     result[band] = best_image[band]
-        
+
         print(f"✅ Successfully processed image from {image_date}")
         return [result]
         

--- a/geo_agent/utils/tools.py
+++ b/geo_agent/utils/tools.py
@@ -835,6 +835,7 @@ async def scan_region_change(
     month2: int,
     top_n: int = 20,
     geometry_s3_url: str = None,
+    bbox: list = None,
 ) -> str:
     """Scan an entire country or large region for land surface change hotspots using Clay AI embeddings.
 
@@ -854,6 +855,9 @@ async def scan_region_change(
         year2: Later year (e.g. 2025)
         month2: Later month (1-12)
         top_n: Number of top hotspots to return (default 20)
+        bbox: OPTIONAL [west, south, east, north] in degrees. PREFERRED way to scan a
+            NAMED SUB-REGION (valley, basin, metro, mountain range): pass the area's
+            approximate extent directly. Do NOT pass the parent state/country name.
         geometry_s3_url: OPTIONAL. For a NAMED SUB-REGION (valley, county, metro, basin,
             mountain range, national forest - anything smaller than a whole supported
             country/state), geocode the area first (find_location_boundary +
@@ -886,12 +890,23 @@ async def scan_region_change(
     try:
         region_lower = region.lower().strip()
         # Resolve the scan bbox. Priority:
-        #   1. An explicit geocoded geometry (sub-regions: valleys, counties, metros,
-        #      basins, parks - anything that is not a whole supported country/state).
-        #   2. An EXACT match in the known whole-country/state table.
-        # We intentionally do NOT substring-match the name against the table, so that
+        #   1. An explicit bbox [west, south, east, north] in degrees - best for a
+        #      named sub-region whose extent the caller knows (valley/basin/metro).
+        #   2. A geocoded geometry (geometry_s3_url) -> use its bounds.
+        #   3. An EXACT match in the known whole-country/state table.
+        # We intentionally do NOT substring-match the name against the table, so
         # "San Luis Valley, Colorado" never collapses to the whole Colorado bbox.
-        if geometry_s3_url:
+        if bbox is not None:
+            try:
+                if isinstance(bbox, str):
+                    bbox = [float(x) for x in bbox.strip("[]() ").split(",")]
+                w, s, e, n = (float(v) for v in bbox)
+                bbox = (w, s, e, n)
+                logger.info("REGION SCAN (explicit bbox): %s %s, %d-%02d -> %d-%02d",
+                            region, bbox, year1, month1, year2, month2)
+            except Exception:
+                return json.dumps({"error": f"Invalid bbox {bbox!r}; expected [west, south, east, north] in degrees."})
+        elif geometry_s3_url:
             try:
                 geom_gdf = download_geometry_from_s3(geometry_s3_url).to_crs("EPSG:4326")
                 minx, miny, maxx, maxy = (float(v) for v in geom_gdf.total_bounds)
@@ -909,9 +924,9 @@ async def scan_region_change(
                 "error": (
                     f"'{region}' is not a recognized whole country or US state. If it is a "
                     f"sub-region (valley, county, metro, basin, park, mountain range, etc.), "
-                    f"geocode it first with find_location_boundary + get_best_geometry, then "
-                    f"call scan_region_change again with geometry_s3_url set to that geometry. "
-                    f"Do NOT substitute the parent state/country."
+                    f"pass its extent directly as bbox=[west, south, east, north] in degrees "
+                    f"(or geometry_s3_url from a geocoded boundary). Do NOT substitute the "
+                    f"parent state/country."
                 ),
                 "supported_whole_regions_sample": sorted(COUNTRY_BBOXES.keys())[:20],
             })

--- a/geo_agent/utils/tools.py
+++ b/geo_agent/utils/tools.py
@@ -834,6 +834,7 @@ async def scan_region_change(
     year2: int,
     month2: int,
     top_n: int = 20,
+    geometry_s3_url: str = None,
 ) -> str:
     """Scan an entire country or large region for land surface change hotspots using Clay AI embeddings.
 
@@ -846,12 +847,19 @@ async def scan_region_change(
     Peru, Costa Rica, etc.) work well.
 
     Args:
-        region: Country name (e.g. "Colombia", "Brazil", "Costa Rica") or "custom" with bbox
+        region: Whole country or US state name (e.g. "Colombia", "Colorado"). For a
+            named SUB-REGION, also pass geometry_s3_url (see below) - do NOT rely on the name.
         year1: Earlier year (e.g. 2020)
         month1: Earlier month (1-12)
         year2: Later year (e.g. 2025)
         month2: Later month (1-12)
         top_n: Number of top hotspots to return (default 20)
+        geometry_s3_url: OPTIONAL. For a NAMED SUB-REGION (valley, county, metro, basin,
+            mountain range, national forest - anything smaller than a whole supported
+            country/state), geocode the area first (find_location_boundary +
+            get_best_geometry) and pass the resulting geometry here; the scan then covers
+            only that area's bounding box. Leave unset only for a whole supported
+            country/US-state named in `region`.
 
     Returns: JSON with:
         - summary: total cells scanned, area covered, % changed, timing
@@ -876,21 +884,37 @@ async def scan_region_change(
     from .lgnd_embeddings import scan_region_change as _scan_region, COUNTRY_BBOXES
 
     try:
-        # Resolve region to bbox
         region_lower = region.lower().strip()
-        if region_lower in COUNTRY_BBOXES:
+        # Resolve the scan bbox. Priority:
+        #   1. An explicit geocoded geometry (sub-regions: valleys, counties, metros,
+        #      basins, parks - anything that is not a whole supported country/state).
+        #   2. An EXACT match in the known whole-country/state table.
+        # We intentionally do NOT substring-match the name against the table, so that
+        # "San Luis Valley, Colorado" never collapses to the whole Colorado bbox.
+        if geometry_s3_url:
+            try:
+                geom_gdf = download_geometry_from_s3(geometry_s3_url).to_crs("EPSG:4326")
+                minx, miny, maxx, maxy = (float(v) for v in geom_gdf.total_bounds)
+                bbox = (minx, miny, maxx, maxy)
+                logger.info("REGION SCAN (geocoded sub-region): %s bbox=%s, %d-%02d -> %d-%02d",
+                            region, bbox, year1, month1, year2, month2)
+            except Exception as e:
+                return json.dumps({"error": f"Could not read geometry for '{region}': {e}"})
+        elif region_lower in COUNTRY_BBOXES:
             bbox = COUNTRY_BBOXES[region_lower]
-            logger.info(f"🌍 REGION SCAN: {region} ({bbox}), {year1}-{month1:02d} → {year2}-{month2:02d}")
+            logger.info("REGION SCAN: %s (%s), %d-%02d -> %d-%02d",
+                        region, bbox, year1, month1, year2, month2)
         else:
-            # Try to find a partial match
-            matches = [k for k in COUNTRY_BBOXES if region_lower in k or k in region_lower]
-            if matches:
-                bbox = COUNTRY_BBOXES[matches[0]]
-                logger.info(f"🌍 REGION SCAN: {region} (matched '{matches[0]}'), {year1}-{month1:02d} → {year2}-{month2:02d}")
-            else:
-                return json.dumps({
-                    "error": f"Unknown region: '{region}'. Supported countries: {', '.join(sorted(COUNTRY_BBOXES.keys())[:20])}... Use run_change_detection with a specific bbox for custom areas."
-                })
+            return json.dumps({
+                "error": (
+                    f"'{region}' is not a recognized whole country or US state. If it is a "
+                    f"sub-region (valley, county, metro, basin, park, mountain range, etc.), "
+                    f"geocode it first with find_location_boundary + get_best_geometry, then "
+                    f"call scan_region_change again with geometry_s3_url set to that geometry. "
+                    f"Do NOT substitute the parent state/country."
+                ),
+                "supported_whole_regions_sample": sorted(COUNTRY_BBOXES.keys())[:20],
+            })
 
         # Check if region is very large (>20 geohashes would be excessive)
         from .lgnd_embeddings import _get_geohashes_for_bbox

--- a/geo_agent/utils/tools.py
+++ b/geo_agent/utils/tools.py
@@ -1186,22 +1186,38 @@ async def run_change_detection(
         nir2_path = download_band(nir_s3_url_date2, "nir_d2")
         green2_path = download_band(green_s3_url_date2, "green_d2")
 
-        # --- Read arrays ---
+        # --- Decide decimation factor from the base (10m) band size ---
+        # Downsampling large AOIs cuts band-read + iMAD cost ~N^2 with negligible
+        # visual impact (change maps are displayed downsampled anyway). Small AOIs
+        # stay full resolution.
+        from rasterio.enums import Resampling
         with rasterio.open(red1_path) as src:
-            red1 = src.read(1)
-            profile = src.profile.copy()
-            transform = src.transform
+            _native_max = max(src.width, src.height)
+        decimate = config.CHANGE_DETECTION_DOWNSAMPLE if _native_max >= 1024 else 1
 
-        with rasterio.open(nir1_path) as src:
-            nir1 = src.read(1)
-        with rasterio.open(green1_path) as src:
-            green1 = src.read(1)
-        with rasterio.open(red2_path) as src:
-            red2 = src.read(1)
-        with rasterio.open(nir2_path) as src:
-            nir2 = src.read(1)
-        with rasterio.open(green2_path) as src:
-            green2 = src.read(1)
+        def _read_band(path):
+            """Read band 1, decimated by `decimate` with averaging resampling."""
+            with rasterio.open(path) as src:
+                oh = max(1, src.height // decimate)
+                ow = max(1, src.width // decimate)
+                return src.read(1, out_shape=(oh, ow), resampling=Resampling.average)
+
+        # --- Read arrays (decimated to a common 10m-equivalent grid) ---
+        with rasterio.open(red1_path) as src:
+            oh = max(1, src.height // decimate)
+            ow = max(1, src.width // decimate)
+            red1 = src.read(1, out_shape=(oh, ow), resampling=Resampling.average)
+            # Scale the transform so the decimated raster stays correctly georeferenced
+            # (keeps per-pixel area, and therefore change-area stats, accurate).
+            transform = src.transform * src.transform.scale(src.width / ow, src.height / oh)
+            profile = src.profile.copy()
+            profile.update({"width": ow, "height": oh, "transform": transform})
+
+        nir1 = _read_band(nir1_path)
+        green1 = _read_band(green1_path)
+        red2 = _read_band(red2_path)
+        nir2 = _read_band(nir2_path)
+        green2 = _read_band(green2_path)
 
         # --- Download optional 20m bands ---
         nir08_1 = nir08_2 = swir2_1 = swir2_2 = None
@@ -1210,25 +1226,18 @@ async def run_change_detection(
             swir2_1_path = download_band(swir2_s3_url_date1, "swir2_d1")
             nir08_2_path = download_band(nir08_s3_url_date2, "nir08_d2")
             swir2_2_path = download_band(swir2_s3_url_date2, "swir2_d2")
-
-            with rasterio.open(nir08_1_path) as src:
-                nir08_1 = src.read(1)
-            with rasterio.open(swir2_1_path) as src:
-                swir2_1 = src.read(1)
-            with rasterio.open(nir08_2_path) as src:
-                nir08_2 = src.read(1)
-            with rasterio.open(swir2_2_path) as src:
-                swir2_2 = src.read(1)
+            nir08_1 = _read_band(nir08_1_path)
+            swir2_1 = _read_band(swir2_1_path)
+            nir08_2 = _read_band(nir08_2_path)
+            swir2_2 = _read_band(swir2_2_path)
 
         # --- Download optional blue band (10m) ---
         blue1 = blue2 = None
         if blue_s3_url_date1 and blue_s3_url_date2:
             blue1_path = download_band(blue_s3_url_date1, "blue_d1")
             blue2_path = download_band(blue_s3_url_date2, "blue_d2")
-            with rasterio.open(blue1_path) as src:
-                blue1 = src.read(1)
-            with rasterio.open(blue2_path) as src:
-                blue2 = src.read(1)
+            blue1 = _read_band(blue1_path)
+            blue2 = _read_band(blue2_path)
 
         # ===================================================================
         # Run Tier 1 (spectral index) and Tier 2 (iMAD) in parallel

--- a/geo_agent/utils/tools.py
+++ b/geo_agent/utils/tools.py
@@ -586,6 +586,82 @@ async def get_rasters(location: str, geometry_s3_url: str = None, current_date_s
     return out
 
 
+def _fetch_and_map_rasters(aoi_gdf, location, current_date_str, max_cloud):
+    """Synchronous worker: search + clip + upload Sentinel-2 bands for ONE date.
+
+    Returns a dict matching get_rasters' output shape, or None if no image found.
+    Safe to run in a thread (get_filtered_images uses unique temp dirs + S3 keys).
+    """
+    bands = ["red", "green", "blue", "nir", "nir08", "swir2"]
+    images = get_filtered_images(aoi_gdf, bands=bands, max_cloud=max_cloud,
+                                 current_date_str=current_date_str, location=location)
+    if not images:
+        images = get_filtered_images(aoi_gdf, bands=bands, max_cloud=80,
+                                     current_date_str=current_date_str, location=location)
+    if not images:
+        return None
+    r = images[0]
+    return {
+        "location": str(location),
+        "date_used": r['date'][:10],
+        "tci_s3_url": r.get('tci_s3_url', ''),
+        "red_s3_url": r.get('red_s3_url', ''),
+        "green_s3_url": r.get('green_s3_url', ''),
+        "blue_s3_url": r.get('blue_s3_url', ''),
+        "nir_s3_url": r.get('nir_s3_url', ''),
+        "nir08_s3_url": r.get('nir08_s3_url', ''),
+        "swir2_s3_url": r.get('swir2_s3_url', ''),
+        "cloud_pct": r.get('cloud_pct'),
+        "tile_id": r.get('tile_id', ''),
+        "coverage_pct": r.get('coverage_pct', ''),
+    }
+
+
+@tool
+async def get_rasters_for_dates(location: str, date1_str: str, date2_str: str,
+                                geometry_s3_url: str = None, max_cloud: float = 30) -> str:
+    """Fetch Sentinel-2 imagery for TWO dates IN PARALLEL. Use this for change
+    detection / before-after comparisons instead of calling get_rasters twice — it
+    resolves the geometry once and fetches both dates concurrently (~2x faster).
+
+    Args:
+        location: Place name (for filenames)
+        date1_str: First date YYYY-MM-DD (END of 60-day search window, e.g. PRE-event)
+        date2_str: Second date YYYY-MM-DD (END of 60-day search window, e.g. POST-event)
+        geometry_s3_url: Boundary from find_location_boundary / get_best_geometry / create_bbox_from_coordinates
+        max_cloud: Max cloud % (default 30, retries at 80)
+
+    Returns: JSON {"date1": {...}, "date2": {...}} where each object has the same
+    fields as get_rasters (tci_s3_url, red_s3_url, green_s3_url, blue_s3_url,
+    nir_s3_url, nir08_s3_url, swir2_s3_url, date_used, cloud_pct). Feed the band URLs
+    straight into run_change_detection."""
+    from concurrent.futures import ThreadPoolExecutor
+
+    logger.info(f"🔍 Fetching rasters for TWO dates in parallel: {date1_str} + {date2_str}")
+    _log_mem("get_rasters_for_dates:start")
+
+    # Resolve geometry once (shared, read-only, by both date fetches)
+    if geometry_s3_url:
+        aoi_gdf = download_geometry_from_s3(geometry_s3_url)
+    else:
+        geocode_result = json.loads(await find_location_boundary(location))
+        aoi_gdf = download_geometry_from_s3(geocode_result["geometry_s3_url"])
+
+    # Fetch both dates concurrently; each fetch also clips/uploads its bands in parallel.
+    with ThreadPoolExecutor(max_workers=2) as ex:
+        f1 = ex.submit(_fetch_and_map_rasters, aoi_gdf, location, date1_str, max_cloud)
+        f2 = ex.submit(_fetch_and_map_rasters, aoi_gdf, location, date2_str, max_cloud)
+        r1, r2 = f1.result(), f2.result()
+
+    missing = [d for d, r in ((date1_str, r1), (date2_str, r2)) if not r]
+    if missing:
+        return json.dumps({"error": f"No satellite images found for {location} on: {', '.join(missing)}"})
+
+    logger.info(f"✅ Both dates fetched in parallel: {r1['date_used']} + {r2['date_used']}")
+    _log_mem("get_rasters_for_dates:end")
+    return json.dumps({"date1": r1, "date2": r2})
+
+
 #####################################
 ### BANDMATH TOOLS
 #####################################


### PR DESCRIPTION
# Sub-region scans + change-detection performance pass

Builds on `test/deploy-integration`. Two themes: correctness for named sub-region
scans, and a sizable speedup pass across both change-detection tools. Each change
is committed separately so they can be reviewed/cherry-picked independently.

## Correctness — named sub-region scans
- **`scan_region_change` no longer collapses a sub-region to the whole state.** The
  old name matcher substring-matched against the country/state table, so
  *"San Luis Valley, Colorado"* matched `colorado` and scanned the entire state.
  Resolution is now: explicit `bbox` → geocoded `geometry_s3_url` → **exact**
  country/state match → otherwise an instruction to geocode (no silent fallback).
- **Added an explicit `bbox=[west, south, east, north]` parameter.** The model
  reliably knows the extent of named regions (it stated the valley's bbox itself in
  testing) but had no way to pass it. The prompt now tells the agent to pass that
  extent for a named sub-region. ("San Luis Valley, Colorado" → scans only the
  valley, hotspots land in view.)

## Performance — region scan (`scan_region_change`)
- **Cosine similarity computed inside DuckDB** (`list_cosine_similarity`) instead of
  a per-cell numpy loop in the Lambda. Embeddings never materialize in Python.
  Dense-partition time ~36s→~10s warm, peak memory ~2.9GB→~0.9GB; results identical
  (verified 159,178 / 17,469 cells on a Colorado scan).
- **Lambda co-located in us-west-2** (the LGND data region) via `LGND_LAMBDA_REGION`
  — CDK stack region, agent invoke client, and the IAM grant ARN all follow it.
- **Lambda right-sized to 2048 MB / 120 s** (the SQL handler peaks ~0.9 GB).

## Performance — pixel change detection (`run_change_detection`)
- **Decimated band reads + iMAD on the downsampled grid.** Bands read at 1/N
  resolution (averaged, N=2 default via `CHANGE_DETECTION_DOWNSAMPLE`) for AOIs
  ≥1024 px, cutting read + iMAD cost ~4×. The output transform is scaled so the
  change map stays correctly georeferenced and area stats remain accurate; small
  AOIs stay full-res. Compute dropped from tens of seconds to ~2 s.

## Performance — imagery fetch (`get_rasters`)
- **Parallel band clip/upload** in `get_filtered_images` (TCI + 6 bands were done
  sequentially; now concurrent).
- **GDAL COG-over-HTTP env vars** (`GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR`, HTTP/2
  multiplexing, range caching) so each `/vsicurl` open skips directory-listing
  probes — speeds up band clips, CRS probes, and change-detection reads.
- **New `get_rasters_for_dates` tool** — fetches both comparison dates in parallel
  (geometry resolved once; both dates' band work overlaps), replacing two sequential
  `get_rasters` calls in the change-detection flow. Registered in the agent and the
  prompt points the change-detection workflow at it.

## Operational fix
- **`deploy.sh`: restored `--non-interactive` on `agentcore configure`.** Without it,
  configure blocks on an interactive prompt in non-TTY/automated deploys and hangs.

## Testing / validation
- Deployed end-to-end to a live account and exercised both flows.
- Region scan: Colorado full-state and the San Luis Valley sub-region both work;
  sub-region now scans only the valley.
- Pixel change detection: noticeably faster `get_rasters` and ~2 s compute; change
  maps and area stats verified against the prior (full-res) output.
- DuckDB-vs-numpy cosine equivalence and the decimated-read georeferencing were
  checked with focused tests before deploying.

## Notes
- The Lambda now deploys to **us-west-2**; deploy `ChangeDetectionStack` there and
  set `LGND_EMBEDDINGS_ENABLED=true` on the agent runtime to enable the region scan.
- `CHANGE_DETECTION_DOWNSAMPLE=1` disables pixel decimation if full resolution is
  ever needed.

## Licensing
I confirm this contribution is made under the terms of the project's license
(see `LICENSE`), and that I am authorized to contribute it.
