### PR TITLE
scan_region_change: deterministic, coherent, distinct hotspots

### DIFF
--- a/geo_agent/utils/lgnd_embeddings.py
+++ b/geo_agent/utils/lgnd_embeddings.py
@@ -320,6 +320,73 @@ COUNTRY_BBOXES = {
 LAMBDA_FUNCTION_NAME = "lgnd-partition-query"
 
 
+def _build_coherence_check(cells, min_neighbors, center_fn):
+    """Return a predicate is_coherent(cell) -> bool.
+
+    A genuine change hotspot is part of a contiguous block of changed cells;
+    isolated single cells are usually cloud / edge / co-registration noise. This
+    requires a cell to have >= min_neighbors changed neighbors (8-connected on the
+    ~1.28km embedding grid). Uses an O(1) grid-hash lookup so it scales to large
+    scans. Returns an always-True predicate when min_neighbors <= 0 (filter off).
+    """
+    import math
+    if not min_neighbors or min_neighbors <= 0:
+        return lambda c: True
+    # Infer grid cell size (degrees) from a sample cell bbox.
+    dx = dy = None
+    for c in cells:
+        b = c.get("bbox")
+        if isinstance(b, dict):
+            w = abs(b.get("xmax", 0) - b.get("xmin", 0))
+            h = abs(b.get("ymax", 0) - b.get("ymin", 0))
+            if w > 0 and h > 0:
+                dx, dy = w, h
+                break
+    if not dx or not dy:
+        return lambda c: True
+
+    # Key on the cell's lower-left CORNER (a grid line), snapped with floor. Using
+    # the center would land on half-cell multiples and hit banker's-rounding
+    # ambiguity that misaligns neighbors; floor on the corner is stable and makes
+    # adjacent cells differ by exactly 1 in each axis regardless of grid origin.
+    def _key(b):
+        return (int(math.floor(b.get("xmin", 0) / dx + 1e-9)),
+                int(math.floor(b.get("ymin", 0) / dy + 1e-9)))
+
+    occupied = {}
+    for c in cells:
+        b = c.get("bbox")
+        if isinstance(b, dict):
+            k = _key(b)
+            occupied[k] = occupied.get(k, 0) + 1
+
+    def _check(c):
+        b = c.get("bbox")
+        if not isinstance(b, dict):
+            return True
+        kx, ky = _key(b)
+        n = 0
+        for ax in (-1, 0, 1):
+            for ay in (-1, 0, 1):
+                if ax == 0 and ay == 0:
+                    continue
+                n += occupied.get((kx + ax, ky + ay), 0)
+        return n >= min_neighbors
+
+    return _check
+
+
+def _haversine_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Great-circle distance in km between two lon/lat points."""
+    import math
+    r = 6371.0
+    p1, p2 = math.radians(lat1), math.radians(lat2)
+    dp = math.radians(lat2 - lat1)
+    dl = math.radians(lon2 - lon1)
+    a = math.sin(dp / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dl / 2) ** 2
+    return 2 * r * math.asin(math.sqrt(a))
+
+
 def _scan_with_lambda_fanout(
     geohashes: list[str],
     bbox: tuple[float, float, float, float],
@@ -328,6 +395,8 @@ def _scan_with_lambda_fanout(
     top_n: int,
     min_change_score: float,
     start_time: float,
+    min_separation_km: float = 0.0,
+    min_neighbors: int = 0,
 ) -> dict:
     """Fan out partition queries to Lambda functions for parallel execution.
 
@@ -398,34 +467,77 @@ def _scan_with_lambda_fanout(
         error_msg = f"No data found. Errors: {'; '.join(errors)}" if errors else "No matching cells"
         return {"error": error_msg, "query_time_s": round(query_time, 1)}
 
-    # Sort by change score and take top N
-    all_changed_cells.sort(key=lambda x: x.get("change_score", 0), reverse=True)
+    # Sort deterministically. change_score saturates at 1.0 for many cells, so a
+    # plain change_score sort leaves ties in non-deterministic Lambda-completion
+    # order (hotspots shuffle between runs). Break ties by:
+    #   1. change_score  (desc) — primary severity
+    #   2. similarity    (asc)  — lower cosine similarity = more semantically
+    #                             changed, a finer discriminator once score hits 1.0
+    #   3. center lat, lon (asc) — fully stable final tie-break
+    def _cell_center(c):
+        b = c.get("bbox") or {}
+        if isinstance(b, dict):
+            return ((b.get("ymin", 0) + b.get("ymax", 0)) / 2.0,
+                    (b.get("xmin", 0) + b.get("xmax", 0)) / 2.0)
+        return (0.0, 0.0)
 
-    # Apply land mask to top candidates only (efficient)
-    filtered_top = []
+    def _sort_key(c):
+        lat, lon = _cell_center(c)
+        return (-round(c.get("change_score", 0), 4),
+                round(c.get("similarity", 1.0), 6),
+                round(lat, 5), round(lon, 5))
+
+    all_changed_cells.sort(key=_sort_key)
+
+    # Coherence filter over the full changed-cell set (isolated cells are noise).
+    _is_coherent = _build_coherence_check(all_changed_cells, min_neighbors, _cell_center)
+
+    # Land-mask candidates. When thinning or coherence is active we must scan a
+    # generous pool (both drop candidates), otherwise the top-N*3 slice is enough.
+    use_full_pool = (min_separation_km and min_separation_km > 0) or (min_neighbors and min_neighbors > 0)
+    pool = all_changed_cells if use_full_pool else all_changed_cells[:top_n * 3]
+    land_cells = []
     ocean_removed = 0
-    for r in all_changed_cells[:top_n * 3]:
+    incoherent_removed = 0
+    for r in pool:
         cell_bbox = r.get("bbox")
-        if cell_bbox:
-            if isinstance(cell_bbox, dict):
-                cx = (cell_bbox.get("xmin", 0) + cell_bbox.get("xmax", 0)) / 2
-                cy = (cell_bbox.get("ymin", 0) + cell_bbox.get("ymax", 0)) / 2
-            else:
-                filtered_top.append(r)
-                continue
-            if _is_on_land(cx, cy):
-                filtered_top.append(r)
-            else:
+        if isinstance(cell_bbox, dict):
+            cx = (cell_bbox.get("xmin", 0) + cell_bbox.get("xmax", 0)) / 2
+            cy = (cell_bbox.get("ymin", 0) + cell_bbox.get("ymax", 0)) / 2
+            if not _is_on_land(cx, cy):
                 ocean_removed += 1
-        else:
-            filtered_top.append(r)
-        if len(filtered_top) >= top_n:
+                continue
+        if not _is_coherent(r):
+            incoherent_removed += 1
+            continue
+        land_cells.append(r)
+        # Fast path: stop early when not thinning and we have enough land cells.
+        if not (min_separation_km and min_separation_km > 0) and len(land_cells) >= top_n:
             break
 
     if ocean_removed > 0:
         print(f"🌊 Filtered {ocean_removed} ocean/water cells")
+    if incoherent_removed > 0:
+        print(f"🔎 Filtered {incoherent_removed} isolated (low-coherence) cells")
 
-    hotspots = filtered_top[:top_n]
+    # Optional spatial thinning: keep hotspots at least `min_separation_km` apart
+    # so the top-N are geographically DISTINCT events instead of a cluster of
+    # adjacent 1.28km cells (all saturating at change_score 1.0). Greedy over the
+    # deterministically-sorted list, so the strongest cell in each area wins.
+    if min_separation_km and min_separation_km > 0:
+        thinned, kept_centers = [], []
+        for r in land_cells:
+            lat, lon = _cell_center(r)
+            if all(_haversine_km(lat, lon, klat, klon) >= min_separation_km
+                   for klat, klon in kept_centers):
+                thinned.append(r)
+                kept_centers.append((lat, lon))
+            if len(thinned) >= top_n:
+                break
+        hotspots = thinned[:top_n]
+        print(f"📍 Spatial thinning: {len(hotspots)} distinct hotspots ≥{min_separation_km}km apart")
+    else:
+        hotspots = land_cells[:top_n]
 
     # Build hotspot list with coordinates
     hotspot_list = []
@@ -528,6 +640,8 @@ def scan_region_change(
     month2: int,
     top_n: int = 20,
     min_change_score: float = 0.15,
+    min_separation_km: float = 0.0,
+    min_neighbors: int = 0,
 ) -> dict:
     """Scan a large region for change hotspots using LGND embeddings.
 
@@ -581,4 +695,6 @@ def scan_region_change(
     return _scan_with_lambda_fanout(
         geohashes, bbox, year1, actual_month1, year2, actual_month2,
         top_n, min_change_score, start_time,
+        min_separation_km=min_separation_km,
+        min_neighbors=min_neighbors,
     )

--- a/geo_agent/utils/tools.py
+++ b/geo_agent/utils/tools.py
@@ -912,6 +912,9 @@ async def scan_region_change(
     top_n: int = 20,
     geometry_s3_url: str = None,
     bbox: list = None,
+    min_change_score: float = 0.25,
+    min_separation_km: float = 3.0,
+    min_neighbors: int = 2,
 ) -> str:
     """Scan an entire country or large region for land surface change hotspots using Clay AI embeddings.
 
@@ -931,6 +934,17 @@ async def scan_region_change(
         year2: Later year (e.g. 2025)
         month2: Later month (1-12)
         top_n: Number of top hotspots to return (default 20)
+        min_change_score: Minimum change score (0-1) a cell must exceed to count as
+            changed (default 0.25). Higher = fewer, more confident changes and a more
+            credible "% changed" statistic; lower (e.g. 0.15) is more permissive.
+        min_separation_km: Spatially thin hotspots so each is at least this many km from
+            the others (default 3.0 ≈ 2 grid cells). Raise to ~8-10 for very spread-out,
+            distinct hotspots; set 0 to disable. Ranking is deterministic (change_score,
+            then similarity, then location), so the same top hotspots return every run.
+        min_neighbors: Coherence filter (default 2). A hotspot cell must have at least this
+            many changed neighbors (8-connected on the 1.28km grid), which drops isolated
+            single-cell hits that are usually cloud/edge noise rather than real change
+            fronts. Set 0 to disable.
         bbox: OPTIONAL [west, south, east, north] in degrees. PREFERRED way to scan a
             NAMED SUB-REGION (valley, basin, metro, mountain range): pass the area's
             approximate extent directly. Do NOT pass the parent state/country name.
@@ -1023,7 +1037,9 @@ async def scan_region_change(
             year2=year2,
             month2=month2,
             top_n=top_n,
-            min_change_score=0.15,
+            min_change_score=min_change_score,
+            min_separation_km=min_separation_km,
+            min_neighbors=min_neighbors,
         )
 
         if "error" in result:


### PR DESCRIPTION
# Improve region-scan hotspot selection: deterministic ranking, spatial coherence filter, and distinct-hotspot thinning

Builds on the change-detection work in PR1 / PR4. Scoped **only** to how
`scan_region_change` chooses and returns hotspots — no new tools, no new
dependencies, no infrastructure changes.

## Summary
The broad-area region scan (`scan_region_change`) found the right *areas* of
change, but the specific top-N hotspots it returned were low quality for drill-in:

1. **Non-deterministic** — the same scan returned different "top" hotspots on
   different runs.
2. **Clustered** — the top-N were often 10 adjacent 1.28 km cells from a single
   event rather than distinct hotspots across the region.
3. **Noisy** — isolated single cells (cloud / edge / co-registration artifacts)
   could rank as hotspots.

This PR makes hotspot selection **deterministic, spatially distinct, and
noise-filtered**, and exposes the selection thresholds as tunable parameters with
sensible new defaults. The scan's coverage, embeddings, math, and density-map
output are unchanged — this only affects which cells are promoted to the ranked
hotspot list.

## Motivation
Hotspot `change_score` **saturates at 1.0** for many cells (embedding vectors go
nearly orthogonal under strong land change), so a plain `sort(change_score)` left
a large block of tied 1.0 cells. Python's stable sort then preserved their
arrival order — and cells arrive in **non-deterministic Lambda-completion order**
(`as_completed` over the geohash fan-out). That undefined tie-break is why the
"top" hotspots shuffled between runs, and why they tended to be whatever adjacent
cluster happened to come back first.

## What's included

**Modified: `geo_agent/utils/lgnd_embeddings.py`**
- **Deterministic ranking.** Replaced the single-key sort with a stable composite
  key: `change_score` desc → `similarity` asc (a finer discriminator once score
  saturates: lower cosine similarity = more transformed) → cell `lat`, `lon`. The
  same top hotspots are now returned on every run.
- **New `_build_coherence_check(cells, min_neighbors, center_fn)`** — an O(1)
  grid-hash predicate that keeps a cell only if it has `>= min_neighbors` changed
  neighbors (8-connected on the 1.28 km grid). Keys off each cell's lower-left
  **corner** with `floor` (grid lines) rather than the center, which avoids a
  half-cell banker's-rounding ambiguity that would otherwise misalign neighbors.
- **New `_haversine_km(...)`** — great-circle distance helper for thinning.
- **Spatial thinning + coherence in hotspot selection.** After the deterministic
  sort and land mask, candidates are (a) dropped if they fail the coherence check
  and (b) greedily thinned so each returned hotspot is `>= min_separation_km` from
  the others — yielding geographically distinct hotspots instead of one tight
  cluster. When either filter is active the selection scans the full changed-cell
  pool (not just `top_n * 3`) so it still fills `top_n`.
- **New parameters** on `_scan_with_lambda_fanout` and the module-level
  `scan_region_change`: `min_separation_km` and `min_neighbors` (both default off
  internally; the agent-facing defaults are set in the tool, below).

**Modified: `geo_agent/utils/tools.py` (the `scan_region_change` tool only)**
- Added three tunable parameters with new defaults and threaded them through to
  the engine:
  - `min_change_score: float = 0.25` (was hardcoded `0.15`) — fewer, more
    confident changes and a more credible "% changed" statistic.
  - `min_separation_km: float = 3.0` (~2 grid cells) — distinct hotspots by
    default.
  - `min_neighbors: int = 2` — coherence filter on by default.
- Updated the tool docstring to document the knobs and their effect.

## Parameters / defaults
| Parameter | New default | Effect | Disable / tune |
|---|---|---|---|
| `min_change_score` | `0.25` | Threshold to count a cell as changed (density + stats) | Lower (`0.15`) = more permissive |
| `min_separation_km` | `3.0` | Min distance between returned hotspots | `0` = off; `8–10` = very spread out |
| `min_neighbors` | `2` | Required changed neighbors (coherence) | `0` = off |

All remain per-call tunable via the tool, so a specific run can widen the spread
or tighten the threshold without a redeploy.

## How it works (selection pipeline)
1. All changed cells are gathered from the Lambda fan-out (unchanged).
2. Cells are sorted by the deterministic composite key above.
3. A coherence predicate is built over the full changed-cell set (grid hash).
4. Candidates are walked in ranked order; each is dropped if it is ocean
   (existing land mask) or fails coherence, then greedily kept only if it is at
   least `min_separation_km` from every already-kept hotspot.
5. The first `top_n` survivors become the ranked hotspots. The full change-density
   map layer is unchanged (it still shows every changed cell).

## Testing / validation
- **Coherence logic unit-tested** against synthetic grids: a solid 3×3 block is
  kept (interior and corner cells), an isolated cell is filtered, a stricter
  `min_neighbors=5` keeps only the interior, and `min_neighbors=0` disables the
  filter. This also caught and fixed the banker's-rounding grid-key bug (cell
  centers landing on half-cell boundaries) by keying off the cell corner with
  `floor`.
- **Deployed and validated live.** An eastern-Rondônia scan now returns top
  hotspots spread across **two distinct areas** (Ji-Paraná and Aripuanã, tens of
  km apart) instead of one adjacent cluster, ran clean end-to-end with the
  coherence + thinning + `0.25` threshold, and the reported change rate tightened
  from ~59% to ~54.5%.
- **Reproducibility:** re-running the same scan returns the same ordered top
  hotspots.

## Notes / limitations
- `change_score` saturation is inherent to the embedding-similarity signal;
  `similarity` is used as the tie-break discriminator rather than trying to
  de-saturate the score.
- Thinning is a greedy pass over the deterministically-ranked list, so the
  strongest cell in each area wins its neighborhood.
- The coherence grid infers cell size from a sample bbox and assumes the regular
  ~1.28 km embedding grid.
- Raising `min_change_score` lowers the headline "% changed" (by design — it is a
  more conservative, defensible number); it does not reorder the already-saturated
  top hotspots.

## Contribution checklist
- [x] Focused on a single concern (region-scan hotspot selection); no unrelated
  changes bundled in.
- [x] No new dependencies, tools, or infrastructure.
- [x] No hardcoded secrets, account IDs, or credentials.
- [x] Parameters remain backward-compatible (additive, with defaults).

## Licensing
I confirm this contribution is made under the terms of the project's license
(see `LICENSE`), and that I am authorized to contribute it.
